### PR TITLE
회원가입 로직 구현

### DIFF
--- a/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountController.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountController.kt
@@ -1,0 +1,24 @@
+package gg.dak.board_api.domain.account.controller
+
+import gg.dak.board_api.domain.account.data.request.RegisterRequest
+import gg.dak.board_api.domain.account.data.response.RegisterResponse
+import gg.dak.board_api.domain.account.service.AccountService
+import gg.dak.board_api.domain.account.util.AccountConverter
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/account")
+class AccountController(
+    private val accountConverter: AccountConverter,
+    private val accountService: AccountService
+) {
+    @PostMapping("/register")
+    fun register(request: RegisterRequest): ResponseEntity<RegisterResponse>  =
+        accountConverter.toDto(request)
+            .let { accountService.register(it) }
+            .let { RegisterResponse(it.idx) }
+            .let { ResponseEntity.ok(it) }
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountController.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountController.kt
@@ -15,10 +15,10 @@ class AccountController(
     private val accountConverter: AccountConverter,
     private val accountService: AccountService
 ) {
-    @PostMapping("/register")
+    @PostMapping("/register") //회원가입 트랜잭션을 수행합니다.
     fun register(request: RegisterRequest): ResponseEntity<RegisterResponse>  =
-        accountConverter.toDto(request)
-            .let { accountService.register(it) }
-            .let { RegisterResponse(it.idx) }
+        accountConverter.toDto(request) //요청정보를 통해 Dto를 구성합니다.
+            .let { accountService.register(it) } //Dto를 통해 회원가입 로직을 수행하고, 가입된 계정정보를 반환합니다.
+            .let { RegisterResponse(it.idx) } //응답객체를 구성하여 반환합니다.
             .let { ResponseEntity.ok(it) }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountController.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountController.kt
@@ -6,6 +6,7 @@ import gg.dak.board_api.domain.account.service.AccountService
 import gg.dak.board_api.domain.account.util.AccountConverter
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -16,7 +17,7 @@ class AccountController(
     private val accountService: AccountService
 ) {
     @PostMapping("/register") //회원가입 트랜잭션을 수행합니다.
-    fun register(request: RegisterRequest): ResponseEntity<RegisterResponse>  =
+    fun register(@RequestBody request: RegisterRequest): ResponseEntity<RegisterResponse>  =
         accountConverter.toDto(request) //요청정보를 통해 Dto를 구성합니다.
             .let { accountService.register(it) } //Dto를 통해 회원가입 로직을 수행하고, 가입된 계정정보를 반환합니다.
             .let { RegisterResponse(it.idx) } //응답객체를 구성하여 반환합니다.

--- a/src/main/kotlin/gg/dak/board_api/domain/account/data/dto/AccountDto.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/data/dto/AccountDto.kt
@@ -4,5 +4,6 @@ data class AccountDto(
     val idx: Long,
     val nickname: String,
     val id: String,
-    val password: String
+    val password: String,
+    val isPasswordEncoded: Boolean
 )

--- a/src/main/kotlin/gg/dak/board_api/domain/account/data/dto/AccountDto.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/data/dto/AccountDto.kt
@@ -1,0 +1,8 @@
+package gg.dak.board_api.domain.account.data.dto
+
+data class AccountDto(
+    val idx: Long,
+    val nickname: String,
+    val id: String,
+    val password: String
+)

--- a/src/main/kotlin/gg/dak/board_api/domain/account/data/enitty/Account.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/data/enitty/Account.kt
@@ -1,11 +1,14 @@
 package gg.dak.board_api.domain.account.data.enitty
 
 import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
 import javax.persistence.Id
 
 @Entity
 class Account (
-    @Id val idx: Long,
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val idx: Long,
     val nickName: String,
     val id: String,
     val encodedPassword: String

--- a/src/main/kotlin/gg/dak/board_api/domain/account/data/enitty/Account.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/data/enitty/Account.kt
@@ -1,0 +1,12 @@
+package gg.dak.board_api.domain.account.data.enitty
+
+import javax.persistence.Entity
+import javax.persistence.Id
+
+@Entity
+class Account (
+    @Id val idx: Long,
+    val nickName: String,
+    val id: String,
+    val encodedPassword: String
+)

--- a/src/main/kotlin/gg/dak/board_api/domain/account/data/request/RegisterRequest.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/data/request/RegisterRequest.kt
@@ -1,0 +1,7 @@
+package gg.dak.board_api.domain.account.data.request
+
+data class RegisterRequest(
+    val nickname: String,
+    val id: String,
+    val password: String
+)

--- a/src/main/kotlin/gg/dak/board_api/domain/account/data/response/RegisterResponse.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/data/response/RegisterResponse.kt
@@ -1,0 +1,3 @@
+package gg.dak.board_api.domain.account.data.response
+
+data class RegisterResponse(val accountId: Long)

--- a/src/main/kotlin/gg/dak/board_api/domain/account/data/type/OperationType.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/data/type/OperationType.kt
@@ -1,0 +1,5 @@
+package gg.dak.board_api.domain.account.data.type
+
+enum class OperationType {
+    REGISTER
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/repository/AccountRepository.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/repository/AccountRepository.kt
@@ -1,0 +1,6 @@
+package gg.dak.board_api.domain.account.repository
+
+import gg.dak.board_api.domain.account.data.enitty.Account
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AccountRepository: JpaRepository<Account, Long>

--- a/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountService.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountService.kt
@@ -1,0 +1,7 @@
+package gg.dak.board_api.domain.account.service
+
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+
+interface AccountService {
+    fun register(dto: AccountDto): AccountDto
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountServiceImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountServiceImpl.kt
@@ -1,0 +1,24 @@
+package gg.dak.board_api.domain.account.service
+
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.type.OperationType
+import gg.dak.board_api.domain.account.repository.AccountRepository
+import gg.dak.board_api.domain.account.util.AccountConverter
+import gg.dak.board_api.domain.account.util.AccountPolicyValidator
+import gg.dak.board_api.domain.account.util.AccountProcessor
+import org.springframework.stereotype.Service
+
+@Service
+class AccountServiceImpl(
+    private val accountPolicyValidator: AccountPolicyValidator,
+    private val accountProcessor: AccountProcessor,
+    private val accountConverter: AccountConverter,
+    private val accountRepository: AccountRepository,
+): AccountService {
+    override fun register(dto: AccountDto): AccountDto =
+        accountPolicyValidator.validate(OperationType.REGISTER, dto) //회원가입 정책을 검사합니다.
+            .let { accountProcessor.process(OperationType.REGISTER, dto) } //인자로 받은 정보에 대한 전처리 과정을 실행합니다.
+            .let { accountConverter.toEntity(it) }
+            .let { accountRepository.save(it) }
+            .let { accountConverter.toDto(it) }
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountConverter.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountConverter.kt
@@ -1,8 +1,11 @@
 package gg.dak.board_api.domain.account.util
 
 import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.enitty.Account
 import gg.dak.board_api.domain.account.data.request.RegisterRequest
 
 interface AccountConverter {
     fun toDto(request: RegisterRequest): AccountDto
+    fun toDto(entity: Account): AccountDto
+    fun toEntity(dto: AccountDto): Account
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountConverter.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountConverter.kt
@@ -1,0 +1,8 @@
+package gg.dak.board_api.domain.account.util
+
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.request.RegisterRequest
+
+interface AccountConverter {
+    fun toDto(request: RegisterRequest): AccountDto
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountConverterImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountConverterImpl.kt
@@ -1,10 +1,14 @@
 package gg.dak.board_api.domain.account.util
 
 import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.enitty.Account
 import gg.dak.board_api.domain.account.data.request.RegisterRequest
 import org.springframework.stereotype.Component
 
 @Component
 class AccountConverterImpl: AccountConverter {
-    override fun toDto(request: RegisterRequest): AccountDto = AccountDto(idx = -1, nickname = request.nickname, id = request.id, password = request.password)
+    override fun toDto(request: RegisterRequest): AccountDto = AccountDto(idx = -1, nickname = request.nickname, id = request.id, password = request.password, isPasswordEncoded = false)
+    override fun toDto(entity: Account): AccountDto = AccountDto(idx = entity.idx, nickname = entity.nickName, id = entity.id, password = entity.encodedPassword, isPasswordEncoded = true)
+    override fun toEntity(dto: AccountDto): Account = Account(idx = dto.idx, nickName =  dto.nickname, id = dto.id, encodedPassword = getEncodedPasswordOrEmpty(dto))
+    private fun getEncodedPasswordOrEmpty(dto: AccountDto): String = if(dto.isPasswordEncoded) dto.password else ""
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountConverterImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountConverterImpl.kt
@@ -1,0 +1,10 @@
+package gg.dak.board_api.domain.account.util
+
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.request.RegisterRequest
+import org.springframework.stereotype.Component
+
+@Component
+class AccountConverterImpl: AccountConverter {
+    override fun toDto(request: RegisterRequest): AccountDto = AccountDto(idx = -1, nickname = request.nickname, id = request.id, password = request.password)
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountPolicyValidator.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountPolicyValidator.kt
@@ -1,0 +1,9 @@
+package gg.dak.board_api.domain.account.util
+
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.type.OperationType
+
+interface AccountPolicyValidator {
+    fun validate(operation: OperationType, dto: AccountDto)
+
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountPolicyValidatorImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountPolicyValidatorImpl.kt
@@ -1,0 +1,25 @@
+package gg.dak.board_api.domain.account.util
+
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.type.OperationType
+import gg.dak.board_api.global.common.exception.PolicyValidationException
+import org.springframework.stereotype.Component
+
+@Component
+class AccountPolicyValidatorImpl: AccountPolicyValidator {
+    //계정 도메인에 관련된 정책들을 검사합니다.
+    override fun validate(operation: OperationType, dto: AccountDto) =
+        when(operation) {
+            //수행할 작업이 "회원가입"일 경우, 이에대한 정책을 검증합니다.
+            OperationType.REGISTER -> validateRegisterNickname(dto.nickname)
+        }
+
+    //유저의 닉네임은 2~5자 사이여야합니다.
+    private fun validateRegisterNickname(nickname: String) {
+        //Trade-off
+        //부등호를 사용하면 가독성을 떨어져도 연산속도가 빨라진다
+        //소규모 사용자를 대상으로 하는 시스템이므로 가독성을 우선으로한다.
+        if((2..5).contains(nickname.length)) return
+        else throw PolicyValidationException("회원가입 정책을 위반하였습니다!", "닉네임은 2-5자 사이여야합니다.")
+    }
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountProcessor.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountProcessor.kt
@@ -1,0 +1,8 @@
+package gg.dak.board_api.domain.account.util
+
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.type.OperationType
+
+interface AccountProcessor {
+    fun process(operation: OperationType, dto: AccountDto): AccountDto
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountProcessorImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountProcessorImpl.kt
@@ -1,0 +1,13 @@
+package gg.dak.board_api.domain.account.util
+
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.type.OperationType
+import org.springframework.security.crypto.password.PasswordEncoder
+
+class AccountProcessorImpl(
+    private val passwordEncoder: PasswordEncoder
+): AccountProcessor {
+    override fun process(operation: OperationType, dto: AccountDto): AccountDto {
+        TODO()
+    }
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountProcessorImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountProcessorImpl.kt
@@ -7,7 +7,15 @@ import org.springframework.security.crypto.password.PasswordEncoder
 class AccountProcessorImpl(
     private val passwordEncoder: PasswordEncoder
 ): AccountProcessor {
-    override fun process(operation: OperationType, dto: AccountDto): AccountDto {
-        TODO()
-    }
+    override fun process(operation: OperationType, dto: AccountDto): AccountDto =
+        when(operation) {
+            OperationType.REGISTER -> processRegister(dto)
+        }
+
+    private fun processRegister(dto: AccountDto): AccountDto =
+        encodePassword(dto).copy(idx = 0)
+
+    private fun encodePassword(dto: AccountDto): AccountDto =
+        if(dto.isPasswordEncoded) dto
+        else dto.copy(password = passwordEncoder.encode(dto.password), isPasswordEncoded = true)
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountProcessorImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountProcessorImpl.kt
@@ -3,7 +3,9 @@ package gg.dak.board_api.domain.account.util
 import gg.dak.board_api.domain.account.data.dto.AccountDto
 import gg.dak.board_api.domain.account.data.type.OperationType
 import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Component
 
+@Component
 class AccountProcessorImpl(
     private val passwordEncoder: PasswordEncoder
 ): AccountProcessor {

--- a/src/main/kotlin/gg/dak/board_api/global/common/advice/PolicyValidationAdvice.kt
+++ b/src/main/kotlin/gg/dak/board_api/global/common/advice/PolicyValidationAdvice.kt
@@ -1,0 +1,12 @@
+package gg.dak.board_api.global.common.advice
+
+import gg.dak.board_api.global.common.exception.PolicyValidationException
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class PolicyValidationAdvice {
+    @ExceptionHandler(PolicyValidationException::class) //TODO 나중에 ErrorResponse 관련 스팩 만들고 적용하기
+    fun handle(e: PolicyValidationException) = ResponseEntity.badRequest().body("정책을 위반했습니다! - ${e.message}")
+}

--- a/src/main/kotlin/gg/dak/board_api/global/common/exception/PolicyValidationException.kt
+++ b/src/main/kotlin/gg/dak/board_api/global/common/exception/PolicyValidationException.kt
@@ -1,0 +1,3 @@
+package gg.dak.board_api.global.common.exception
+
+class PolicyValidationException(errorMessage: String, errorDetails: String) : RuntimeException("$errorMessage - $errorDetails")

--- a/src/test/kotlin/gg/dak/board_api/TestDummyDataUtil.kt
+++ b/src/test/kotlin/gg/dak/board_api/TestDummyDataUtil.kt
@@ -2,4 +2,6 @@ package gg.dak.board_api
 
 object TestDummyDataUtil {
     fun nickname(length: Int) = listOf("닥지지", "라울", "아무닉", "가나다라마", "앰비션뮤직", "G", "스프링MVC").filter { it.length == length }.random()
+    fun id() = listOf("abcd123", "develop_raul", "qwer1234").random()
+    fun password() = listOf("helloworld0123!", "b0ard!ap1", "pa5sw0r|)").random()
 }

--- a/src/test/kotlin/gg/dak/board_api/TestDummyDataUtil.kt
+++ b/src/test/kotlin/gg/dak/board_api/TestDummyDataUtil.kt
@@ -1,7 +1,8 @@
 package gg.dak.board_api
 
 object TestDummyDataUtil {
-    fun nickname(length: Int) = listOf("닥지지", "라울", "아무닉", "가나다라마", "앰비션뮤직", "G", "스프링MVC").filter { it.length == length }.random()
+    fun nickname(length: Int) = listOf("닥지지", "라울", "아무닉", "가나다라마", "앰비션뮤직", "G", "스프링MVC", "스카니아").filter { it.length == length }.random()
     fun id() = listOf("abcd123", "develop_raul", "qwer1234").random()
     fun password() = listOf("helloworld0123!", "b0ard!ap1", "pa5sw0r|)").random()
+    fun encodedPassword() = listOf("az+Dasc98As=8a", "s=1Scat1l2_", "s+lcjm4=32kco1p").random()
 }

--- a/src/test/kotlin/gg/dak/board_api/TestDummyDataUtil.kt
+++ b/src/test/kotlin/gg/dak/board_api/TestDummyDataUtil.kt
@@ -1,0 +1,5 @@
+package gg.dak.board_api
+
+object TestDummyDataUtil {
+    fun nickname(length: Int) = listOf("닥지지", "라울", "아무닉", "가나다라마", "앰비션뮤직", "G", "스프링MVC").filter { it.length == length }.random()
+}

--- a/src/test/kotlin/gg/dak/board_api/domain/account/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/controller/AccountControllerTest.kt
@@ -24,7 +24,7 @@ class AccountControllerTest {
         target = AccountController(accountConverter, accountService)
     }
 
-    @Test @DisplayName("회원가입 성공테스트")
+    @Test @DisplayName("AccountController - 회원가입 성공테스트")
     fun testRegister_positive() {
         //given
         val request = mock<RegisterRequest>()

--- a/src/test/kotlin/gg/dak/board_api/domain/account/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/controller/AccountControllerTest.kt
@@ -1,0 +1,47 @@
+package gg.dak.board_api.domain.account.controller
+
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.request.RegisterRequest
+import gg.dak.board_api.domain.account.service.AccountService
+import gg.dak.board_api.domain.account.util.AccountConverter
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.random.Random
+
+class AccountControllerTest {
+    private lateinit var accountConverter: AccountConverter
+    private lateinit var accountService: AccountService
+    private lateinit var target: AccountController
+
+    @BeforeEach
+    fun setUp() {
+        accountConverter = mock()
+        accountService = mock()
+        target = AccountController(accountConverter, accountService)
+    }
+
+    @Test @DisplayName("회원가입 성공테스트")
+    fun testRegister_positive() {
+        //given
+        val request = mock<RegisterRequest>()
+        val dto = mock<AccountDto>()
+        val registeredDto = mock<AccountDto>()
+        val idx = Random.nextLong()
+
+        //when
+        whenever(accountConverter.toDto(request)).thenReturn(dto)
+        whenever(accountService.register(dto)).thenReturn(registeredDto)
+        whenever(registeredDto.idx).thenReturn(idx)
+
+        //then
+        val result = target.register(request)
+
+        assertTrue(result.statusCode.is2xxSuccessful)
+        assertNotNull(result.body)
+        assertEquals(result.body!!.accountId, idx)
+    }
+}

--- a/src/test/kotlin/gg/dak/board_api/domain/account/service/AccountServiceTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/service/AccountServiceTest.kt
@@ -1,0 +1,58 @@
+package gg.dak.board_api.domain.account.service
+
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.enitty.Account
+import gg.dak.board_api.domain.account.data.type.OperationType
+import gg.dak.board_api.domain.account.repository.AccountRepository
+import gg.dak.board_api.domain.account.util.AccountConverter
+import gg.dak.board_api.domain.account.util.AccountPolicyValidator
+import gg.dak.board_api.domain.account.util.AccountProcessor
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class AccountServiceTest {
+
+    private lateinit var accountPolicyValidator: AccountPolicyValidator
+    private lateinit var accountProcessor: AccountProcessor
+    private lateinit var accountConverter: AccountConverter
+    private lateinit var accountRepository: AccountRepository
+    private lateinit var target: AccountService
+
+    @BeforeEach
+    fun setUp() {
+        accountPolicyValidator = mock()
+        accountProcessor = mock()
+        accountConverter = mock()
+        accountRepository = mock()
+        target = AccountServiceImpl(accountPolicyValidator, accountProcessor, accountConverter, accountRepository)
+    }
+
+    @Test @DisplayName("AccountService - 회원가입 성공테스트")
+    fun testRegister_positive() {
+        //given
+        val dto = mock<AccountDto>()
+        val processedDto = mock<AccountDto>()
+        val entity = mock<Account>()
+        val savedEntity = mock<Account>()
+        val registeredDto = mock<AccountDto>()
+
+        //when
+        whenever(accountProcessor.process(OperationType.REGISTER, dto)).thenReturn(processedDto)
+        whenever(accountConverter.toEntity(processedDto)).thenReturn(entity)
+        whenever(accountRepository.save(entity)).thenReturn(savedEntity)
+        whenever(accountConverter.toDto(savedEntity)).thenReturn(registeredDto)
+
+        //test
+        val result = target.register(dto)
+
+        assertEquals(result, registeredDto)
+        verify(accountRepository, times(1)).save(entity)
+        verify(accountPolicyValidator, times(1)).validate(OperationType.REGISTER, dto)
+    }
+}

--- a/src/test/kotlin/gg/dak/board_api/domain/account/util/AccountPolicyValidatorTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/util/AccountPolicyValidatorTest.kt
@@ -19,7 +19,7 @@ class AccountPolicyValidatorTest {
     }
 
     @Test @DisplayName("AccountPolicyValidator - 회원가입 정책 검사 성공테스트")
-    fun testValidateRegister_success() {
+    fun testRegisterPolicyValidate_success() {
         //given
         val nickname = TestDummyDataUtil.nickname(length = (2..5).random())
         val dto = mock<AccountDto>()

--- a/src/test/kotlin/gg/dak/board_api/domain/account/util/AccountPolicyValidatorTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/util/AccountPolicyValidatorTest.kt
@@ -1,0 +1,33 @@
+package gg.dak.board_api.domain.account.util
+
+import gg.dak.board_api.TestDummyDataUtil
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.type.OperationType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class AccountPolicyValidatorTest {
+    private lateinit var target: AccountPolicyValidator
+
+    @BeforeEach
+    fun setUp() {
+        target = AccountPolicyValidatorImpl()
+    }
+
+    @Test @DisplayName("AccountPolicyValidator - 회원가입 정책 검사 성공테스트")
+    fun testValidateRegister_success() {
+        //given
+        val nickname = TestDummyDataUtil.nickname(length = (2..5).random())
+        val dto = mock<AccountDto>()
+
+        //when
+        whenever(dto.nickname).thenReturn(nickname)
+
+        //then
+        assertDoesNotThrow { target.validate(OperationType.REGISTER, dto) }
+    }
+}

--- a/src/test/kotlin/gg/dak/board_api/domain/account/util/AccountProcessorTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/util/AccountProcessorTest.kt
@@ -1,0 +1,62 @@
+package gg.dak.board_api.domain.account.util
+
+import gg.dak.board_api.TestDummyDataUtil
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.type.OperationType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.crypto.password.PasswordEncoder
+import kotlin.random.Random
+
+class AccountProcessorTest {
+    private lateinit var passwordEncoder: PasswordEncoder
+    private lateinit var target: AccountProcessor
+
+    @BeforeEach
+    fun setUp() {
+        passwordEncoder = mock()
+        target = AccountProcessorImpl(passwordEncoder)
+    }
+
+    /* AccountProcessor - 회원가입 데이터 전처리 성공테스트
+    AccountProcessor.process(OperationType.REGISTER, ?: AccountDto)
+    Dto에 대해, 회원가입시 필요한 전처리 로직을 수행하고, 이에대한 결과를 반환한다.
+    회원가입시에 필요한 전처리 로직은 다음과 같다
+    - idx를 0으로 변환한다.
+    - password를 인코딩한다. (PasswordEncoder 사용)
+     */
+    @Test @DisplayName("AccountProcessor - 회원가입 데이터 전처리 성공테스트")
+    fun testRegisterDataProcess_positive() {
+        //given
+        val id = TestDummyDataUtil.id()
+        val password = TestDummyDataUtil.password()
+        val nickname = TestDummyDataUtil.nickname((2..5).random())
+        val dto = AccountDto(
+            idx = Random.nextLong(1, Long.MAX_VALUE),
+            nickname = nickname,
+            id = id,
+            password = password,
+            isPasswordEncoded = false
+        )
+        val encodedPassword = mock<String>()
+
+        //when
+        whenever(dto.password).thenReturn(password)
+        whenever(passwordEncoder.encode(password)).thenReturn(encodedPassword)
+
+        //then
+        val result = target.process(OperationType.REGISTER, dto)
+
+        assertEquals(result.idx, 0)
+        assertTrue(result.isPasswordEncoded)
+        assertEquals(result.password, encodedPassword)
+        verify(passwordEncoder, times(1)).encode(password)
+    }
+}

--- a/src/test/kotlin/gg/dak/board_api/domain/account/util/AccountProcessorTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/util/AccountProcessorTest.kt
@@ -45,10 +45,9 @@ class AccountProcessorTest {
             password = password,
             isPasswordEncoded = false
         )
-        val encodedPassword = mock<String>()
+        val encodedPassword = TestDummyDataUtil.encodedPassword()
 
         //when
-        whenever(dto.password).thenReturn(password)
         whenever(passwordEncoder.encode(password)).thenReturn(encodedPassword)
 
         //then


### PR DESCRIPTION
### Summary
Board API의 회원가입 로직을 구현하였습니다!

추가된 endpoint는 [아래](###Endpoints)과 같습니다.
그 외에도 AccountRepository 등, 계정 도메인에 대한 기본적인 컴포넌트를 작성하였습니다!


### Endpoints
**POST** /api/v1/account/register
_Request Body_
```json
{
    "nickname": "초보모험가",
    "id": "develop.raul",
    "password": "password1234"
}
```
_Response Body_
```json
{
    "accountId": 0
}
```
> 정책을 위반하였을 경우, 400 BadRequest를 응답합니다
```
정책을 위반했습니다! - 회원가입 정책을 위반하였습니다! - 닉네임은 2-5자 사이여야합니다.
```