### PR TITLE
계정정보 조회로직 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,15 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+    jacoco
     id("org.springframework.boot") version "2.7.3"
     id("io.spring.dependency-management") version "1.0.13.RELEASE"
     kotlin("jvm") version "1.6.21"
     kotlin("plugin.spring") version "1.6.21"
     kotlin("plugin.jpa") version "1.6.21"
 }
+
+jacoco { toolVersion = "0.8.8" }
 
 group = "gg.dak"
 version = "0.0.1-SNAPSHOT"

--- a/src/main/kotlin/gg/dak/board_api/domain/account/advice/AccountControllerAdvice.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/advice/AccountControllerAdvice.kt
@@ -1,18 +1,19 @@
-package gg.dak.board_api.global.common.advice
+package gg.dak.board_api.domain.account.advice
 
-import gg.dak.board_api.global.common.exception.PolicyValidationException
+import gg.dak.board_api.domain.account.controller.AccountController
+import gg.dak.board_api.domain.account.exception.UnknownUuidTokenException
 import gg.dak.board_api.global.error.ErrorResponse
 import gg.dak.board_api.global.error.ErrorStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
-@RestControllerAdvice
-class PolicyValidationAdvice {
-    @ExceptionHandler(PolicyValidationException::class)
-    fun handle(e: PolicyValidationException) =
+@RestControllerAdvice(basePackageClasses = [AccountController::class])
+class AccountControllerAdvice {
+    @ExceptionHandler(UnknownUuidTokenException::class)
+    fun handle(e: UnknownUuidTokenException) =
         ErrorResponse(
-            status = ErrorStatus.POLICY_VIOLATION,
+            status = ErrorStatus.UNKNOWN_TOKEN,
             message = e.getErrorMessage(),
             details = e.getErrorDetails()
         ).let { ResponseEntity.badRequest().body(it) }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryController.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryController.kt
@@ -1,6 +1,11 @@
 package gg.dak.board_api.domain.account.controller
 
+import gg.dak.board_api.domain.account.data.response.AccountQueryResponse
+import gg.dak.board_api.domain.account.data.response.PageableAccountQueryResponse
+import gg.dak.board_api.domain.account.service.AccountQueryService
+import gg.dak.board_api.domain.account.util.AccountQueryConverter
 import io.swagger.annotations.Api
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -11,19 +16,27 @@ import org.springframework.web.bind.annotation.RestController
 @Api(tags = ["계정 조회 API"])
 @RestController
 @RequestMapping("/api/v1/account/query")
-class AccountQueryController {
+class AccountQueryController(
+    private val accountQueryService: AccountQueryService,
+    private val accountQueryConverter: AccountQueryConverter
+) {
     @GetMapping("/all")
-    fun findAllAccountWithPagination(@RequestParam("page") page: Int, @RequestParam("size") size: Int): ResponseEntity<*> {
-        TODO()
-    }
+    fun findAllAccountWithPagination(
+        @RequestParam("page") page: Int,
+        @RequestParam("size") size: Int
+    ): ResponseEntity<PageableAccountQueryResponse> =
+        accountQueryService.findAllAccount(PageRequest.of(page, size))
+            .map { accountQueryConverter.toResponse(it) }
+            .let { accountQueryConverter.toPageabelResponse(it.toList()) }
+            .let { ResponseEntity.ok(it) }
 
     @GetMapping("/{idx}")
-    fun findAccountByIndex(@PathVariable idx: String): ResponseEntity<*> {
+    fun findAccountByIndex(@PathVariable idx: String): ResponseEntity<AccountQueryResponse> {
         TODO()
     }
 
     @GetMapping("/id/{id}")
-    fun findAccountById(@PathVariable id: String): ResponseEntity<*> {
+    fun findAccountById(@PathVariable id: String): ResponseEntity<AccountQueryResponse> {
         TODO()
     }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryController.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryController.kt
@@ -1,0 +1,29 @@
+package gg.dak.board_api.domain.account.controller
+
+import io.swagger.annotations.Api
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Api(tags = ["계정 조회 API"])
+@RestController
+@RequestMapping("/api/v1/account/query")
+class AccountQueryController {
+    @GetMapping("/all")
+    fun findAllAccountWithPagination(@RequestParam("page") page: Int, @RequestParam("size") size: Int): ResponseEntity<*> {
+        TODO()
+    }
+
+    @GetMapping("/{idx}")
+    fun findAccountByIndex(@PathVariable idx: String): ResponseEntity<*> {
+        TODO()
+    }
+
+    @GetMapping("/id/{id}")
+    fun findAccountById(@PathVariable id: String): ResponseEntity<*> {
+        TODO()
+    }
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryController.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryController.kt
@@ -37,7 +37,8 @@ class AccountQueryController(
             .let { ResponseEntity.ok(it) }
 
     @GetMapping("/id/{id}")
-    fun findAccountById(@PathVariable id: String): ResponseEntity<AccountQueryResponse> {
-        TODO()
-    }
+    fun findAccountById(@PathVariable id: String): ResponseEntity<AccountQueryResponse> =
+         accountQueryService.findAccountById(id)
+             .let { accountQueryConverter.toResponse(it) }
+             .let { ResponseEntity.ok(it) }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryController.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryController.kt
@@ -31,9 +31,10 @@ class AccountQueryController(
             .let { ResponseEntity.ok(it) }
 
     @GetMapping("/{idx}")
-    fun findAccountByIndex(@PathVariable idx: String): ResponseEntity<AccountQueryResponse> {
-        TODO()
-    }
+    fun findAccountByIndex(@PathVariable idx: Long): ResponseEntity<AccountQueryResponse> =
+        accountQueryService.findAccountByIndex(idx)
+            .let { accountQueryConverter.toResponse(it) }
+            .let { ResponseEntity.ok(it) }
 
     @GetMapping("/id/{id}")
     fun findAccountById(@PathVariable id: String): ResponseEntity<AccountQueryResponse> {

--- a/src/main/kotlin/gg/dak/board_api/domain/account/data/response/AccountQueryResponse.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/data/response/AccountQueryResponse.kt
@@ -1,0 +1,7 @@
+package gg.dak.board_api.domain.account.data.response
+
+data class AccountQueryResponse(
+    val idx: Long,
+    val nickname: String,
+    val id: String
+)

--- a/src/main/kotlin/gg/dak/board_api/domain/account/data/response/PageableAccountQueryResponse.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/data/response/PageableAccountQueryResponse.kt
@@ -1,0 +1,7 @@
+package gg.dak.board_api.domain.account.data.response
+
+import org.springframework.data.domain.Page
+
+data class PageableAccountQueryResponse(
+    val data: Page<AccountQueryResponse>
+)

--- a/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryService.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryService.kt
@@ -7,4 +7,5 @@ import org.springframework.data.domain.PageRequest
 interface AccountQueryService {
     fun findAllAccount(pagination: PageRequest): Page<AccountDto>
     fun findAccountByIndex(idx: Long): AccountDto
+    fun findAccountById(id: String): AccountDto
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryService.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryService.kt
@@ -1,0 +1,9 @@
+package gg.dak.board_api.domain.account.service
+
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+
+interface AccountQueryService {
+    fun findAllAccount(pagination: PageRequest): Page<AccountDto>
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryService.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryService.kt
@@ -6,4 +6,5 @@ import org.springframework.data.domain.PageRequest
 
 interface AccountQueryService {
     fun findAllAccount(pagination: PageRequest): Page<AccountDto>
+    fun findAccountByIndex(idx: Long): AccountDto
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceImpl.kt
@@ -20,11 +20,14 @@ class AccountQueryServiceImpl(
     override fun findAccountByIndex(idx: Long): AccountDto =
         accountRepository.findById(idx)
             .let {
-                if(it.isEmpty) throw UnknownAccountException("존재하지 않는 계정의 인덱스입니다! - $idx")
+                if (it.isEmpty) throw UnknownAccountException("존재하지 않는 계정의 인덱스입니다! - $idx")
                 else it.get()
             }.let { accountConverter.toDto(it) }
 
-    override fun findAccountById(id: String): AccountDto {
-        TODO("Not yet implemented")
-    }
+    override fun findAccountById(id: String): AccountDto =
+        accountRepository.findById(id)
+            .let {
+                if (it.isEmpty) throw UnknownAccountException("존재하지 않는 계정의 ID입니다! - $id")
+                else it.get()
+            }.let { accountConverter.toDto(it) }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceImpl.kt
@@ -1,0 +1,18 @@
+package gg.dak.board_api.domain.account.service
+
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.util.AccountConverter
+import gg.dak.board_api.global.account.repository.AccountRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+
+@Service
+class AccountQueryServiceImpl(
+    private val accountRepository: AccountRepository,
+    private val accountConverter: AccountConverter
+): AccountQueryService {
+    override fun findAllAccount(pagination: PageRequest): Page<AccountDto> =
+        accountRepository.findBy(pagination)
+            .map { accountConverter.toDto(it) }
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceImpl.kt
@@ -15,4 +15,8 @@ class AccountQueryServiceImpl(
     override fun findAllAccount(pagination: PageRequest): Page<AccountDto> =
         accountRepository.findBy(pagination)
             .map { accountConverter.toDto(it) }
+
+    override fun findAccountByIndex(idx: Long): AccountDto {
+        TODO("Not yet implemented")
+    }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceImpl.kt
@@ -2,6 +2,7 @@ package gg.dak.board_api.domain.account.service
 
 import gg.dak.board_api.domain.account.data.dto.AccountDto
 import gg.dak.board_api.domain.account.util.AccountConverter
+import gg.dak.board_api.global.account.exception.UnknownAccountException
 import gg.dak.board_api.global.account.repository.AccountRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
@@ -16,7 +17,10 @@ class AccountQueryServiceImpl(
         accountRepository.findBy(pagination)
             .map { accountConverter.toDto(it) }
 
-    override fun findAccountByIndex(idx: Long): AccountDto {
-        TODO("Not yet implemented")
-    }
+    override fun findAccountByIndex(idx: Long): AccountDto =
+        accountRepository.findById(idx)
+            .let {
+                if(it.isEmpty) throw UnknownAccountException("존재하지 않는 계정의 인덱스입니다! - $idx")
+                else it.get()
+            }.let { accountConverter.toDto(it) }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceImpl.kt
@@ -23,4 +23,8 @@ class AccountQueryServiceImpl(
                 if(it.isEmpty) throw UnknownAccountException("존재하지 않는 계정의 인덱스입니다! - $idx")
                 else it.get()
             }.let { accountConverter.toDto(it) }
+
+    override fun findAccountById(id: String): AccountDto {
+        TODO("Not yet implemented")
+    }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountQueryConverter.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountQueryConverter.kt
@@ -1,0 +1,11 @@
+package gg.dak.board_api.domain.account.util
+
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.response.AccountQueryResponse
+import gg.dak.board_api.domain.account.data.response.PageableAccountQueryResponse
+
+interface AccountQueryConverter {
+    fun toResponse(dto: AccountDto): AccountQueryResponse
+    fun toPageabelResponse(list: List<AccountQueryResponse>): PageableAccountQueryResponse
+
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/impl/AccountQueryConverterImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/impl/AccountQueryConverterImpl.kt
@@ -1,0 +1,14 @@
+package gg.dak.board_api.domain.account.util.impl
+
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.response.AccountQueryResponse
+import gg.dak.board_api.domain.account.data.response.PageableAccountQueryResponse
+import gg.dak.board_api.domain.account.util.AccountQueryConverter
+import org.springframework.data.domain.PageImpl
+import org.springframework.stereotype.Component
+
+@Component
+class AccountQueryConverterImpl: AccountQueryConverter {
+    override fun toResponse(dto: AccountDto): AccountQueryResponse = AccountQueryResponse(idx = dto.idx, nickname = dto.nickname, id = dto.id)
+    override fun toPageabelResponse(list: List<AccountQueryResponse>): PageableAccountQueryResponse = PageableAccountQueryResponse(PageImpl(list))
+}

--- a/src/main/kotlin/gg/dak/board_api/global/account/repository/AccountRepository.kt
+++ b/src/main/kotlin/gg/dak/board_api/global/account/repository/AccountRepository.kt
@@ -1,9 +1,12 @@
 package gg.dak.board_api.global.account.repository
 
 import gg.dak.board_api.domain.account.data.enitty.Account
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
 
 interface AccountRepository: JpaRepository<Account, Long> {
     fun findById(id: String): Optional<Account>
+    fun findBy(pageable: Pageable): Page<Account>
 }

--- a/src/test/kotlin/gg/dak/board_api/TestDummyDataUtil.kt
+++ b/src/test/kotlin/gg/dak/board_api/TestDummyDataUtil.kt
@@ -1,6 +1,7 @@
 package gg.dak.board_api
 
 import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.enitty.Account
 import kotlin.random.Random
 
 object TestDummyDataUtil {
@@ -9,5 +10,16 @@ object TestDummyDataUtil {
     fun password() = listOf("helloworld0123!", "b0ard!ap1", "pa5sw0r|)").random()
     fun encodedPassword() = listOf("az+Dasc98As=8a", "s=1Scat1l2_", "s+lcjm4=32kco1p").random()
     fun token() = listOf("98A2+az+DSs=8sca1c2_", "cjStl2_m41lsca=1", "csjca12+at1llm4=3ascko1p").random()
-    fun account(isPasswordEncoded: Boolean) = AccountDto(Random.nextLong(), nickname((2..5).random()), id(), password(), isPasswordEncoded)
+    fun accountDto(isPasswordEncoded: Boolean) = AccountDto(
+        idx = Random.nextLong(),
+        nickname = nickname((2..5).random()),
+        id = id(),
+        password = if(isPasswordEncoded) encodedPassword() else password(),
+        isPasswordEncoded = isPasswordEncoded
+    )
+    fun account() = Account(
+        idx = Random.nextLong(),
+        nickName = nickname((2..5).random()),
+        id = id(),
+        encodedPassword = encodedPassword())
 }

--- a/src/test/kotlin/gg/dak/board_api/TestDummyDataUtil.kt
+++ b/src/test/kotlin/gg/dak/board_api/TestDummyDataUtil.kt
@@ -1,9 +1,13 @@
 package gg.dak.board_api
 
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import kotlin.random.Random
+
 object TestDummyDataUtil {
     fun nickname(length: Int) = listOf("닥지지", "라울", "아무닉", "가나다라마", "앰비션뮤직", "G", "스프링MVC", "스카니아").filter { it.length == length }.random()
     fun id() = listOf("abcd123", "develop_raul", "qwer1234").random()
     fun password() = listOf("helloworld0123!", "b0ard!ap1", "pa5sw0r|)").random()
     fun encodedPassword() = listOf("az+Dasc98As=8a", "s=1Scat1l2_", "s+lcjm4=32kco1p").random()
     fun token() = listOf("98A2+az+DSs=8sca1c2_", "cjStl2_m41lsca=1", "csjca12+at1llm4=3ascko1p").random()
+    fun account(isPasswordEncoded: Boolean) = AccountDto(Random.nextLong(), nickname((2..5).random()), id(), password(), isPasswordEncoded)
 }

--- a/src/test/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryControllerTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryControllerTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import kotlin.math.absoluteValue
 import kotlin.random.Random
 
 class AccountQueryControllerTest {
@@ -36,10 +37,10 @@ class AccountQueryControllerTest {
     @Test @DisplayName("AccountQueryController - 전체 계정목록 조회 성공테스트")
     fun testFindAllAccountWithPagination_positive() {
         //given
-        val page = Random.nextInt()
+        val page = Random.nextInt().absoluteValue
         val size = (0..100).random()
         val pagination = PageRequest.of(page, size)
-        val accounts = (1..size).map { TestDummyDataUtil.account(isPasswordEncoded = true) }
+        val accounts = (1..size).map { TestDummyDataUtil.accountDto(isPasswordEncoded = true) }
         val data = PageImpl(accounts)
         val response = mock<AccountQueryResponse>()
         val pageableResponse = mock<PageableAccountQueryResponse>()

--- a/src/test/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryControllerTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryControllerTest.kt
@@ -1,0 +1,58 @@
+package gg.dak.board_api.domain.account.controller
+
+import gg.dak.board_api.TestDummyDataUtil
+import gg.dak.board_api.domain.account.data.response.AccountQueryResponse
+import gg.dak.board_api.domain.account.data.response.PageableAccountQueryResponse
+import gg.dak.board_api.domain.account.service.AccountQueryService
+import gg.dak.board_api.domain.account.util.AccountQueryConverter
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import kotlin.random.Random
+
+class AccountQueryControllerTest {
+    private lateinit var accountQueryService: AccountQueryService
+    private lateinit var accountQueryConverter: AccountQueryConverter
+    private lateinit var target: AccountQueryController
+
+    @BeforeEach
+    fun setUp() {
+        accountQueryService = mock()
+        accountQueryConverter = mock()
+        target = AccountQueryController(accountQueryService, accountQueryConverter)
+    }
+
+    /* AccountQueryController - 전체 계정목록 조회 성공테스트
+    AccountQueryController.findAllAccountWithPagination(?: Int, ?: Int)
+    요청에 있는 페이지네이션 정보를 통해, 페이지네이션된 계정목록을 조회하고, 반환한다.
+    페이지네이션 계정목록의 조회는 AccountQueryService에게 위임한다.
+    */
+    @Test @DisplayName("AccountQueryController - 전체 계정목록 조회 성공테스트")
+    fun testFindAllAccountWithPagination_positive() {
+        //given
+        val page = Random.nextInt()
+        val size = (0..100).random()
+        val pagination = PageRequest.of(page, size)
+        val accounts = (1..size).map { TestDummyDataUtil.account(isPasswordEncoded = true) }
+        val data = PageImpl(accounts)
+        val response = mock<AccountQueryResponse>()
+        val pageableResponse = mock<PageableAccountQueryResponse>()
+
+        //when
+        whenever(accountQueryService.findAllAccount(pagination)).thenReturn(data)
+        whenever(accountQueryConverter.toResponse(any())).thenReturn(response)
+        whenever(accountQueryConverter.toPageabelResponse(any())).thenReturn(pageableResponse)
+
+        //then
+        val result = target.findAllAccountWithPagination(page = page, size = size)
+        assertTrue(result.statusCode.is2xxSuccessful)
+        assertNotNull(result.body)
+        assertEquals(result.body, pageableResponse)
+    }
+}

--- a/src/test/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryControllerTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryControllerTest.kt
@@ -80,4 +80,27 @@ class AccountQueryControllerTest {
         assertNotNull(result.body)
         assertEquals(result.body, response)
     }
+
+    /* AccountQueryController - ID로 계정조회 성공테스트
+    AccountQueryController.findAccountById(?: String)
+    요청에 있는 ID를 통해, 계정을 조회한다.
+    계정 조회로직은 AccountQueryService에게 위임한다.
+     */
+    @Test @DisplayName("AccountQueryController - ID로 계정조회 성공테스트")
+    fun testFindAccountById_positive() {
+        //given
+        val id = TestDummyDataUtil.id()
+        val dto = mock<AccountDto>()
+        val response = mock<AccountQueryResponse>()
+
+        //when
+        whenever(accountQueryService.findAccountById(id)).thenReturn(dto)
+        whenever(accountQueryConverter.toResponse(dto)).thenReturn(response)
+
+        //then
+        val result = target.findAccountById(id)
+        assertTrue(result.statusCode.is2xxSuccessful)
+        assertNotNull(result.body)
+        assertEquals(result.body, response)
+    }
 }

--- a/src/test/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryControllerTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryControllerTest.kt
@@ -1,6 +1,7 @@
 package gg.dak.board_api.domain.account.controller
 
 import gg.dak.board_api.TestDummyDataUtil
+import gg.dak.board_api.domain.account.data.dto.AccountDto
 import gg.dak.board_api.domain.account.data.response.AccountQueryResponse
 import gg.dak.board_api.domain.account.data.response.PageableAccountQueryResponse
 import gg.dak.board_api.domain.account.service.AccountQueryService
@@ -55,5 +56,28 @@ class AccountQueryControllerTest {
         assertTrue(result.statusCode.is2xxSuccessful)
         assertNotNull(result.body)
         assertEquals(result.body, pageableResponse)
+    }
+
+    /* AccountQueryController - 인덱스로 계정 조회 성공테스트
+    AccountQueryController.findAccountByIndex(?: Long)
+    요청에 있는 인덱스를 통해, 계정을 조회한다.
+    계정 조회로직은 AccountQueryService에게 위임한다.
+     */
+    @Test @DisplayName("AccountQueryController - 인덱스로 계정 조회 성공테스트")
+    fun testFindAccountByIndex_positive() {
+        //given
+        val idx = Random.nextLong()
+        val dto = mock<AccountDto>()
+        val response = mock<AccountQueryResponse>()
+
+        //when
+        whenever(accountQueryService.findAccountByIndex(idx)).thenReturn(dto)
+        whenever(accountQueryConverter.toResponse(dto)).thenReturn(response)
+
+        //then
+        val result = target.findAccountByIndex(idx)
+        assertTrue(result.statusCode.is2xxSuccessful)
+        assertNotNull(result.body)
+        assertEquals(result.body, response)
     }
 }

--- a/src/test/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceTest.kt
@@ -5,6 +5,7 @@ import gg.dak.board_api.domain.account.data.dto.AccountDto
 import gg.dak.board_api.domain.account.data.enitty.Account
 import gg.dak.board_api.domain.account.util.AccountConverter
 import gg.dak.board_api.global.account.repository.AccountRepository
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -14,6 +15,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import java.util.*
 import kotlin.math.absoluteValue
 import kotlin.random.Random
 
@@ -34,7 +36,7 @@ class AccountQueryServiceTest {
     인자로 받은 PageRequest를 통해 페이지네이션된 계정목록을 조회한다.
      */
     @Test @DisplayName("AccountQueryService - 전체 계정목록 조회 성공테스트")
-    fun testFindAllAccount() {
+    fun testFindAllAccount_positive() {
         //given
         val page = Random.nextInt().absoluteValue
         val size = (1..100).random()
@@ -50,5 +52,26 @@ class AccountQueryServiceTest {
         //then
         val result = target.findAllAccount(pagination)
         assertTrue(result.content.stream().allMatch{ it == dto })
+    }
+
+    /* AccountQueryService - 인덱스로 계정 조회 성공테스트
+    AccountQueryService.findAccountByIndex(?: Long)
+    인자로 받은 인덱스를 통해 계정을 조회한다.
+     */
+    @Test @DisplayName("AccountQueryService - 인덱스로 계정 조회 성공테스트")
+    fun testFindAccountByIndex_positive() {
+        //given
+        val idx = Random.nextLong()
+        val entity = mock<Account>()
+        val optional = Optional.of(entity)
+        val dto = mock<AccountDto>()
+
+        //when
+        whenever(accountRepository.findById(idx)).thenReturn(optional)
+        whenever(accountConverter.toDto(entity)).thenReturn(dto)
+
+        //then
+        val result = target.findAccountByIndex(idx)
+        assertEquals(result, dto)
     }
 }

--- a/src/test/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceTest.kt
@@ -1,0 +1,54 @@
+package gg.dak.board_api.domain.account.service
+
+import gg.dak.board_api.TestDummyDataUtil
+import gg.dak.board_api.domain.account.data.dto.AccountDto
+import gg.dak.board_api.domain.account.data.enitty.Account
+import gg.dak.board_api.domain.account.util.AccountConverter
+import gg.dak.board_api.global.account.repository.AccountRepository
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import kotlin.math.absoluteValue
+import kotlin.random.Random
+
+class AccountQueryServiceTest {
+    private lateinit var accountRepository: AccountRepository
+    private lateinit var accountConverter: AccountConverter
+    private lateinit var target: AccountQueryService
+
+    @BeforeEach
+    fun setUp() {
+        accountRepository = mock()
+        accountConverter = mock()
+        target = AccountQueryServiceImpl(accountRepository, accountConverter)
+    }
+
+    /* AccountQueryService - 전체 계정목록 조회 성공테스트
+    AccountQueryService.findAllAccount(?: PageRequest)
+    인자로 받은 PageRequest를 통해 페이지네이션된 계정목록을 조회한다.
+     */
+    @Test @DisplayName("AccountQueryService - 전체 계정목록 조회 성공테스트")
+    fun testFindAllAccount() {
+        //given
+        val page = Random.nextInt().absoluteValue
+        val size = (1..100).random()
+        val pagination = PageRequest.of(page, size)
+        val accounts = (1..size).map { TestDummyDataUtil.account() }
+        val data = PageImpl(accounts)
+        val dto = mock<AccountDto>()
+
+        //when
+        whenever(accountRepository.findBy(pagination)).thenReturn(data)
+        whenever(accountConverter.toDto(any<Account>())).thenReturn(dto)
+
+        //then
+        val result = target.findAllAccount(pagination)
+        assertTrue(result.content.stream().allMatch{ it == dto })
+    }
+}

--- a/src/test/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/service/AccountQueryServiceTest.kt
@@ -74,4 +74,25 @@ class AccountQueryServiceTest {
         val result = target.findAccountByIndex(idx)
         assertEquals(result, dto)
     }
+
+    /* AccountQueryService - ID로 계정조회 성공테스트
+    AccountQueryService.findAccountById(?: String)
+    인자로 받은 ID를 통해 계정을 조회한다.
+     */
+    @Test @DisplayName("AccountQueryService - ID로 계정 조회 성공테스트")
+    fun testFindAccountById_positive() {
+        //given
+        val id = TestDummyDataUtil.id()
+        val entity = mock<Account>()
+        val optional = Optional.of(entity)
+        val dto = mock<AccountDto>()
+
+        //when
+        whenever(accountRepository.findById(id)).thenReturn(optional)
+        whenever(accountConverter.toDto(entity)).thenReturn(dto)
+
+        //then
+        val result = target.findAccountById(id)
+        assertEquals(result, dto)
+    }
 }


### PR DESCRIPTION
## Summary
계정정보에 대한 조회로직을 구현하였습니다!

추가된 endpoint는 [아래](###Endpoints)와 같습니다.

### Endpoint
**GET** /api/v1/account/query/{idx}
_ResponseBody_
```json
{
  "idx": 1,
  "nickname": "초보모험가",
  "id": "develop.raul"
}
```
**GET** /api/v1/account/query/all?page={page}&size={size}
_ResponseBody_
```json
{
  "data": {
    "content": [
      {
        "id": "string",
        "idx": 0,
        "nickname": "string"
      }
    ],
    "empty": true,
    "first": true,
    "last": true,
    "number": 0,
    "numberOfElements": 0,
    "pageable": {
      "offset": 0,
      "pageNumber": 0,
      "pageSize": 0,
      "paged": true,
      "sort": {
        "empty": true,
        "sorted": true,
        "unsorted": true
      },
      "unpaged": true
    },
    "size": 0,
    "sort": {
      "empty": true,
      "sorted": true,
      "unsorted": true
    },
    "totalElements": 0,
    "totalPages": 0
  }
}
```
**GET** /api/v1/account/query/id/{id}
_ResponseBody_
```json
{
  "idx": 1,
  "nickname": "초보모험가",
  "id": "develop.raul"
}
```