### PR TITLE
게시글 삭제 관련 로직 구현

### DIFF
--- a/src/main/kotlin/gg/dak/board_api/domain/post/controller/PostController.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/controller/PostController.kt
@@ -2,6 +2,7 @@ package gg.dak.board_api.domain.post.controller
 
 import gg.dak.board_api.domain.post.data.request.CreatePostRequest
 import gg.dak.board_api.domain.post.data.response.CreatePostResponse
+import gg.dak.board_api.domain.post.data.response.DeletePostResponse
 import gg.dak.board_api.domain.post.service.PostService
 import gg.dak.board_api.domain.post.util.PostConverter
 import gg.dak.board_api.global.security.service.LoginAccountService
@@ -20,16 +21,18 @@ class PostController(
         loginAccountService.getLoginAccount().idx
             .let { postConverter.toDto(request, it) }
             .let { postService.createPost(it) }
-            .let { postConverter.toResponse(it) }
+            .let { postConverter.toCreateResponse(it) }
             .let { ResponseEntity.ok(it) }
 
-    @DeleteMapping("/{id}")
-    fun deletePost(@PathVariable id: String) {
+    @DeleteMapping("/{idx}")
+    fun deletePost(@PathVariable idx: Long): ResponseEntity<DeletePostResponse> =
+        postConverter.toDto(idx)
+            .let { postService.deletePost(it) }
+            .let { postConverter.toDeleteResponse(it) }
+            .let { ResponseEntity.ok(it) }
 
-    }
-
-    @PutMapping("/{id}")
-    fun changePost(@PathVariable id: String) {
+    @PutMapping("/{idx}")
+    fun changePost(@PathVariable idx: String) {
 
     }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/data/event/PostDeleteEvent.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/data/event/PostDeleteEvent.kt
@@ -1,0 +1,3 @@
+package gg.dak.board_api.domain.post.data.event
+
+data class PostDeleteEvent(val idx: Long)

--- a/src/main/kotlin/gg/dak/board_api/domain/post/data/response/DeletePostResponse.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/data/response/DeletePostResponse.kt
@@ -1,3 +1,3 @@
 package gg.dak.board_api.domain.post.data.response
 
-data class DeletePostResponse(val deletedPostId: Long)
+data class DeletePostResponse(val deletedPostIdx: Long)

--- a/src/main/kotlin/gg/dak/board_api/domain/post/data/response/DeletePostResponse.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/data/response/DeletePostResponse.kt
@@ -1,0 +1,3 @@
+package gg.dak.board_api.domain.post.data.response
+
+data class DeletePostResponse(val deletedPostId: Long)

--- a/src/main/kotlin/gg/dak/board_api/domain/post/data/type/BoardType.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/data/type/BoardType.kt
@@ -4,5 +4,5 @@ package gg.dak.board_api.domain.post.data.type
 아직 게시판의 동적 추가가 필요할 정도로 서비스의 복잡성이 증대하지않았으므로, Enum을 통해 게시판을 구현한다.
  */
 enum class BoardType(val displayName: String) {
-    NOTICE("공지사항"), FREE("자유 게시판"), ATTENDANCE("출석 게시판")
+    NOTICE("공지사항"), FREE("자유 게시판"), ATTENDANCE("출석 게시판"), UNKNOWN("@UNKNOWN")
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/data/type/CategoryType.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/data/type/CategoryType.kt
@@ -1,5 +1,5 @@
 package gg.dak.board_api.domain.post.data.type
 
 enum class CategoryType(val displayName: String) {
-    CHAT("잡담"), QUESTION("질문"), HUMOR("유머")
+    CHAT("잡담"), QUESTION("질문"), HUMOR("유머"), UNKNOWN("@UNKNOWN")
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/data/type/PostOperationType.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/data/type/PostOperationType.kt
@@ -1,5 +1,6 @@
 package gg.dak.board_api.domain.post.data.type
 
 enum class PostOperationType {
-    CREATE
+    CREATE,
+    DELETE
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/service/PostService.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/service/PostService.kt
@@ -4,4 +4,5 @@ import gg.dak.board_api.domain.post.data.dto.PostDto
 
 interface PostService {
     fun createPost(dto: PostDto): PostDto
+    fun deletePost(dto: PostDto): PostDto
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/service/PostServiceImpl.kt
@@ -27,4 +27,8 @@ class PostServiceImpl(
                 postConverter.toCreateEvent(it)
                 .let { event -> applicationEventPublisher.publishEvent(event) }
             }
+
+    override fun deletePost(dto: PostDto): PostDto {
+        TODO("Not yet implemented")
+    }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/service/PostServiceImpl.kt
@@ -28,7 +28,12 @@ class PostServiceImpl(
                 .let { event -> applicationEventPublisher.publishEvent(event) }
             }
 
-    override fun deletePost(dto: PostDto): PostDto {
-        TODO("Not yet implemented")
-    }
+    override fun deletePost(dto: PostDto): PostDto =
+        postValidator.validate(PostOperationType.DELETE, dto)
+            .let { postProcessor.process(PostOperationType.DELETE, dto) }
+            .also { postRepository.deleteById(dto.idx) }
+            .also {
+                postConverter.toDeleteEvent(it.idx)
+                .let { event -> applicationEventPublisher.publishEvent(event) }
+            }.let { dto }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverter.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverter.kt
@@ -3,6 +3,7 @@ package gg.dak.board_api.domain.post.util
 import gg.dak.board_api.domain.post.data.dto.PostDto
 import gg.dak.board_api.domain.post.data.entity.Post
 import gg.dak.board_api.domain.post.data.event.PostCreateEvent
+import gg.dak.board_api.domain.post.data.event.PostDeleteEvent
 import gg.dak.board_api.domain.post.data.request.CreatePostRequest
 import gg.dak.board_api.domain.post.data.response.CreatePostResponse
 import gg.dak.board_api.domain.post.data.response.DeletePostResponse
@@ -15,4 +16,5 @@ interface PostConverter {
     fun toEntity(dto: PostDto): Post
     fun toDto(entity: Post): PostDto
     fun toCreateEvent(dto: PostDto): PostCreateEvent
+    fun toDeleteEvent(idx: Long): PostDeleteEvent
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverter.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverter.kt
@@ -5,12 +5,14 @@ import gg.dak.board_api.domain.post.data.entity.Post
 import gg.dak.board_api.domain.post.data.event.PostCreateEvent
 import gg.dak.board_api.domain.post.data.request.CreatePostRequest
 import gg.dak.board_api.domain.post.data.response.CreatePostResponse
+import gg.dak.board_api.domain.post.data.response.DeletePostResponse
 
 interface PostConverter {
+    fun toDto(idx: Long): PostDto
     fun toDto(request: CreatePostRequest, writerIdx: Long): PostDto
-    fun toResponse(dto: PostDto): CreatePostResponse
+    fun toCreateResponse(dto: PostDto): CreatePostResponse
+    fun toDeleteResponse(dto: PostDto): DeletePostResponse
     fun toEntity(dto: PostDto): Post
     fun toDto(entity: Post): PostDto
     fun toCreateEvent(dto: PostDto): PostCreateEvent
-
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
@@ -61,7 +61,5 @@ class PostConverterImpl: PostConverter {
         category = dto.category,
     )
 
-    override fun toDeleteEvent(idx: Long): PostDeleteEvent {
-        TODO("Not yet implemented")
-    }
+    override fun toDeleteEvent(idx: Long): PostDeleteEvent = PostDeleteEvent(idx = idx)
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
@@ -5,10 +5,15 @@ import gg.dak.board_api.domain.post.data.entity.Post
 import gg.dak.board_api.domain.post.data.event.PostCreateEvent
 import gg.dak.board_api.domain.post.data.request.CreatePostRequest
 import gg.dak.board_api.domain.post.data.response.CreatePostResponse
+import gg.dak.board_api.domain.post.data.response.DeletePostResponse
 import org.springframework.stereotype.Component
 
 @Component
 class PostConverterImpl: PostConverter {
+    override fun toDto(idx: Long): PostDto {
+        TODO("Not yet implemented")
+    }
+
     override fun toDto(request: CreatePostRequest, writerIdx: Long): PostDto = PostDto(
             idx = -1,
             title = request.title,
@@ -27,7 +32,10 @@ class PostConverterImpl: PostConverter {
         board = entity.board
     )
 
-    override fun toResponse(dto: PostDto): CreatePostResponse = CreatePostResponse(idx = dto.idx)
+    override fun toCreateResponse(dto: PostDto): CreatePostResponse = CreatePostResponse(idx = dto.idx)
+    override fun toDeleteResponse(dto: PostDto): DeletePostResponse {
+        TODO("Not yet implemented")
+    }
 
     override fun toEntity(dto: PostDto): Post = Post(
         idx = dto.idx,

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
@@ -6,13 +6,20 @@ import gg.dak.board_api.domain.post.data.event.PostCreateEvent
 import gg.dak.board_api.domain.post.data.request.CreatePostRequest
 import gg.dak.board_api.domain.post.data.response.CreatePostResponse
 import gg.dak.board_api.domain.post.data.response.DeletePostResponse
+import gg.dak.board_api.domain.post.data.type.BoardType
+import gg.dak.board_api.domain.post.data.type.CategoryType
 import org.springframework.stereotype.Component
 
 @Component
 class PostConverterImpl: PostConverter {
-    override fun toDto(idx: Long): PostDto {
-        TODO("Not yet implemented")
-    }
+    override fun toDto(idx: Long): PostDto = PostDto(
+        idx = idx,
+        title = "title",
+        content = "content",
+        writerIdx = -1,
+        category = CategoryType.UNKNOWN,
+        board = BoardType.UNKNOWN
+    )
 
     override fun toDto(request: CreatePostRequest, writerIdx: Long): PostDto = PostDto(
             idx = -1,
@@ -33,9 +40,7 @@ class PostConverterImpl: PostConverter {
     )
 
     override fun toCreateResponse(dto: PostDto): CreatePostResponse = CreatePostResponse(idx = dto.idx)
-    override fun toDeleteResponse(dto: PostDto): DeletePostResponse {
-        TODO("Not yet implemented")
-    }
+    override fun toDeleteResponse(dto: PostDto): DeletePostResponse = DeletePostResponse(deletedPostIdx = dto.idx)
 
     override fun toEntity(dto: PostDto): Post = Post(
         idx = dto.idx,

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
@@ -3,6 +3,7 @@ package gg.dak.board_api.domain.post.util
 import gg.dak.board_api.domain.post.data.dto.PostDto
 import gg.dak.board_api.domain.post.data.entity.Post
 import gg.dak.board_api.domain.post.data.event.PostCreateEvent
+import gg.dak.board_api.domain.post.data.event.PostDeleteEvent
 import gg.dak.board_api.domain.post.data.request.CreatePostRequest
 import gg.dak.board_api.domain.post.data.response.CreatePostResponse
 import gg.dak.board_api.domain.post.data.response.DeletePostResponse
@@ -59,4 +60,8 @@ class PostConverterImpl: PostConverter {
         board = dto.board,
         category = dto.category,
     )
+
+    override fun toDeleteEvent(idx: Long): PostDeleteEvent {
+        TODO("Not yet implemented")
+    }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostProcessorImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostProcessorImpl.kt
@@ -9,6 +9,6 @@ class PostProcessorImpl: PostProcessor {
     override fun process(operation: PostOperationType, dto: PostDto): PostDto =
         when(operation) {
             PostOperationType.CREATE -> dto.copy(idx = 0) //게시글 생성시, 인덱스를 0으로 초기화한다.
-            PostOperationType.DELETE -> TODO()
+            PostOperationType.DELETE -> dto //게시글 삭제시, 어떠한 처리 없이, 그대로 반환한다.
         }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostProcessorImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostProcessorImpl.kt
@@ -9,5 +9,6 @@ class PostProcessorImpl: PostProcessor {
     override fun process(operation: PostOperationType, dto: PostDto): PostDto =
         when(operation) {
             PostOperationType.CREATE -> dto.copy(idx = 0) //게시글 생성시, 인덱스를 0으로 초기화한다.
+            PostOperationType.DELETE -> TODO()
         }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostValidatorImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostValidatorImpl.kt
@@ -4,19 +4,30 @@ import gg.dak.board_api.domain.post.config.PostProperties
 import gg.dak.board_api.domain.post.data.dto.PostDto
 import gg.dak.board_api.domain.post.data.type.PostOperationType
 import gg.dak.board_api.domain.post.repository.DailyPostCountRepository
+import gg.dak.board_api.domain.post.repository.PostRepository
 import gg.dak.board_api.global.common.exception.PolicyValidationException
+import gg.dak.board_api.global.security.service.LoginAccountService
 import org.springframework.stereotype.Component
 
 @Component
 class PostValidatorImpl(
     private val postProperties: PostProperties,
-    private val dailyPostCountRepository: DailyPostCountRepository
+    private val postRepository: PostRepository,
+    private val dailyPostCountRepository: DailyPostCountRepository,
+    private val loginAccountService: LoginAccountService
 ): PostValidator {
     override fun validate(type: PostOperationType, dto: PostDto) {
         when(type) {
             PostOperationType.CREATE -> validateDailyPostLimit(dto)
+            PostOperationType.DELETE -> validateIsOwner(dto)
         }
     }
+
+    private fun validateIsOwner(dto: PostDto) =
+        postRepository.findById(dto.idx)
+            .let { if(it.isEmpty) throw PolicyValidationException("포스트 삭제 정책을 위반하였습니다!", "존재하지 않는 게시글입니다.") else it.get() }
+            .let { it.writerIdx == loginAccountService.getLoginAccount().idx}
+            .let { isOwner -> if(!isOwner) throw PolicyValidationException("포스트 삭제 정책을 위반하였습니다!", "포스트 작성자만 포스트를 삭제할 수 있습니다!") }
 
     private fun validateDailyPostLimit(dto: PostDto) =
         dailyPostCountRepository.findByAccountIdxAndBoard(dto.writerIdx, dto.board)

--- a/src/test/kotlin/gg/dak/board_api/domain/post/controller/PostControllerTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/post/controller/PostControllerTest.kt
@@ -3,6 +3,7 @@ package gg.dak.board_api.domain.post.controller
 import gg.dak.board_api.domain.post.data.dto.PostDto
 import gg.dak.board_api.domain.post.data.request.CreatePostRequest
 import gg.dak.board_api.domain.post.data.response.CreatePostResponse
+import gg.dak.board_api.domain.post.data.response.DeletePostResponse
 import gg.dak.board_api.domain.post.service.PostService
 import gg.dak.board_api.domain.post.util.PostConverter
 import gg.dak.board_api.global.security.service.LoginAccountService
@@ -42,10 +43,30 @@ class PostControllerTest {
         whenever(loginAccountService.getLoginAccount().idx).thenReturn(writerIdx)
         whenever(postConverter.toDto(request, writerIdx)).thenReturn(dto)
         whenever(postService.createPost(dto)).thenReturn(createdDto)
-        whenever(postConverter.toResponse(createdDto)).thenReturn(response)
+        whenever(postConverter.toCreateResponse(createdDto)).thenReturn(response)
 
         //then
         val result = target.createPost(request)
+        assertTrue(result.statusCode.is2xxSuccessful)
+        assertNotNull(result.body)
+        assertEquals(result.body, response)
+    }
+
+    @Test @DisplayName("PostController - 포스트 제거 성공테스트")
+    fun testDeletePost_positive() {
+        //given
+        val idx = Random.nextLong()
+        val dto = mock<PostDto>()
+        val deletedDto = mock<PostDto>()
+        val response = mock<DeletePostResponse>()
+
+        //when
+        whenever(postConverter.toDto(idx)).thenReturn(dto)
+        whenever(postService.deletePost(dto)).thenReturn(deletedDto)
+        whenever(postConverter.toDeleteResponse(deletedDto)).thenReturn(response)
+
+        //then
+        val result = target.deletePost(idx)
         assertTrue(result.statusCode.is2xxSuccessful)
         assertNotNull(result.body)
         assertEquals(result.body, response)

--- a/src/test/kotlin/gg/dak/board_api/domain/post/service/PostServiceTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/post/service/PostServiceTest.kt
@@ -3,6 +3,7 @@ package gg.dak.board_api.domain.post.service
 import gg.dak.board_api.domain.post.data.dto.PostDto
 import gg.dak.board_api.domain.post.data.entity.Post
 import gg.dak.board_api.domain.post.data.event.PostCreateEvent
+import gg.dak.board_api.domain.post.data.event.PostDeleteEvent
 import gg.dak.board_api.domain.post.data.type.PostOperationType
 import gg.dak.board_api.domain.post.repository.PostRepository
 import gg.dak.board_api.domain.post.util.PostConverter
@@ -17,6 +18,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.context.ApplicationEventPublisher
+import kotlin.random.Random
 
 class PostServiceTest {
     private lateinit var postConverter: PostConverter
@@ -57,6 +59,26 @@ class PostServiceTest {
         val result = target.createPost(dto)
         assertEquals(result, savedDto)
         verify(postValidator, times(1)).validate(PostOperationType.CREATE, dto)
+        verify(applicationEventPublisher, times(1)).publishEvent(event)
+    }
+
+    @Test @DisplayName("PostService - 포스트 제거 성공테스트")
+    fun testDeletePost_positive() {
+        //given
+        val idx = Random.nextLong()
+        val dto = mock<PostDto>()
+        val processedDto = mock<PostDto>()
+        val event = mock<PostDeleteEvent>()
+
+        //when
+        whenever(postProcessor.process(PostOperationType.DELETE, dto)).thenReturn(processedDto)
+        whenever(processedDto.idx).thenReturn(idx)
+        whenever(postConverter.toDeleteEvent(idx)).thenReturn(event)
+
+        //then
+        val result = target.deletePost(dto)
+        assertEquals(result, dto)
+        verify(postValidator, times(1)).validate(PostOperationType.DELETE, dto)
         verify(applicationEventPublisher, times(1)).publishEvent(event)
     }
 }

--- a/src/test/kotlin/gg/dak/board_api/domain/post/util/PostProcessorTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/post/util/PostProcessorTest.kt
@@ -30,4 +30,15 @@ class PostProcessorTest {
         val result = target.process(PostOperationType.CREATE, dto)
         assertEquals(result, processedDto)
     }
+
+    @Test @DisplayName("PostProcessor - 포스트 제거 전처리 로직 성공테스트")
+    fun testProcessDeletePost_positive() {
+        //given
+        val dto = mock<PostDto>()
+
+
+        //then
+        val result = target.process(PostOperationType.DELETE, dto)
+        assertEquals(result, dto)
+    }
 }

--- a/src/test/kotlin/gg/dak/board_api/domain/post/util/PostValidatorTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/post/util/PostValidatorTest.kt
@@ -3,9 +3,13 @@ package gg.dak.board_api.domain.post.util
 import gg.dak.board_api.domain.post.config.PostProperties
 import gg.dak.board_api.domain.post.data.dto.PostDto
 import gg.dak.board_api.domain.post.data.entity.DailyPostCount
+import gg.dak.board_api.domain.post.data.entity.Post
 import gg.dak.board_api.domain.post.data.type.BoardType
 import gg.dak.board_api.domain.post.data.type.PostOperationType
 import gg.dak.board_api.domain.post.repository.DailyPostCountRepository
+import gg.dak.board_api.domain.post.repository.PostRepository
+import gg.dak.board_api.global.account.data.dto.AccountDto
+import gg.dak.board_api.global.security.service.LoginAccountService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -17,21 +21,25 @@ import kotlin.random.Random
 
 class PostValidatorTest {
     private lateinit var postProperties: PostProperties
+    private lateinit var postRepository: PostRepository
     private lateinit var dailyPostCountRepository: DailyPostCountRepository
+    private lateinit var loginAccountService: LoginAccountService
     private lateinit var target: PostValidator
 
     @BeforeEach
     fun setUp() {
         postProperties = mock()
+        postRepository = mock()
         dailyPostCountRepository = mock()
-        target = PostValidatorImpl(postProperties, dailyPostCountRepository)
+        loginAccountService = mock()
+        target = PostValidatorImpl(postProperties, postRepository, dailyPostCountRepository, loginAccountService)
     }
 
-    /* PolicyValidator - 게시글 생성 로즉 검증 성공테스트
+    /* PolicyValidator - 게시글 작성 로직 검증 성공테스트
     PolicyValidator.validate(PostOperationType.CREATE, ?: PostDto)
-    해당 게시판에 대해, 작성자가 일일 작성 가능 횟수를 초과했는지 검증한다.
+    작성자가 일일 작성 가능 횟수를 초과하였다면, 게시글을 작성할 수 없다.
      */
-    @Test @DisplayName("PolicyValidator - 게시글 생성 로직 검증 성공테스트A")
+    @Test @DisplayName("PolicyValidator - 게시글 작성 로직 검증 성공테스트A")
     fun testValidateCreatePost_positive() {
         //given
         val board = BoardType.values().random()
@@ -50,5 +58,30 @@ class PostValidatorTest {
 
         //then
         assertDoesNotThrow { target.validate(PostOperationType.CREATE, dto) }
+    }
+    //TODO 일일 작성 게시글 정보가 없을 경우(오늘 첫 작성일 경우) 성공테스트 작성
+
+    /* PolicyValidator - 게시글 삭제 로직 검증 성공테스트
+    PolicyValidator.validate(PostOperationType.DELETE, ?: PostDto)
+    요청자가 작성자가 아니라면, 게시글을 삭제할 수 없다.
+    TODO: 랭킹에 등록되어있는 게시글은 삭제할 수 없다.
+     */
+    @Test @DisplayName("PolicyValidator - 게시글 삭제 로직 검증 성공테스트")
+    fun testValidateDeletePost_positive() {
+        //given
+        val dto = mock<PostDto>()
+        val entity = mock<Post>()
+        val ownerIdx = Random.nextLong()
+        val optional = Optional.of(entity)
+        val accountDto = mock<AccountDto>()
+
+        //when
+        whenever(postRepository.findById(dto.idx)).thenReturn(optional)
+        whenever(entity.writerIdx).thenReturn(ownerIdx)
+        whenever(loginAccountService.getLoginAccount()).thenReturn(accountDto)
+        whenever(accountDto.idx).thenReturn(ownerIdx)
+
+        //then
+        assertDoesNotThrow { target.validate(PostOperationType.DELETE, dto) }
     }
 }

--- a/src/test/kotlin/gg/dak/board_api/domain/post/util/PostValidatorTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/post/util/PostValidatorTest.kt
@@ -40,7 +40,7 @@ class PostValidatorTest {
     작성자가 일일 작성 가능 횟수를 초과하였다면, 게시글을 작성할 수 없다.
      */
     @Test @DisplayName("PolicyValidator - 게시글 작성 로직 검증 성공테스트A")
-    fun testValidateCreatePost_positive() {
+    fun testValidateCreatePost_positiveA() {
         //given
         val board = BoardType.values().random()
         val dailyPostLimit = (1..1000).random()
@@ -59,7 +59,23 @@ class PostValidatorTest {
         //then
         assertDoesNotThrow { target.validate(PostOperationType.CREATE, dto) }
     }
-    //TODO 일일 작성 게시글 정보가 없을 경우(오늘 첫 작성일 경우) 성공테스트 작성
+
+    @Test @DisplayName("PolicyValidator - 게시글 작성 로직 검증 성공테스트B")
+    fun testValidateCreatePost_positiveB() {
+        //given
+        val board = BoardType.values().random()
+        val dailyPostLimit = (1..1000).random()
+        val accountIdx = Random.nextLong()
+        val dto = mock<PostDto>()
+        val optional = Optional.empty<DailyPostCount>()
+
+        //when
+        whenever(postProperties.dailyPostLimit).thenReturn(dailyPostLimit)
+        whenever(dailyPostCountRepository.findByAccountIdxAndBoard(accountIdx, board)).thenReturn(optional)
+
+        //then
+        assertDoesNotThrow { target.validate(PostOperationType.CREATE, dto) }
+    }
 
     /* PolicyValidator - 게시글 삭제 로직 검증 성공테스트
     PolicyValidator.validate(PostOperationType.DELETE, ?: PostDto)


### PR DESCRIPTION
### Summary
게시글에 대한 삭제로직을 구현하였습니다!

추가된 endpoint는 [아래](###Endpoints)와 같습니다

### Endpoint
**DELETE** /api/v1/post
_ResponseBody_
```json
{
  "deletedPostIdx": 1
}
```
> 정책을 위반하였을 경우, 400 BadRequest를 응답합니다
```json
{
  "status": "POLICY_VIOLATION",
  "message": "포스트 삭제 정책을 위반하였습니다!",
  "details": "포스트 작성자만 포스트를 삭제할 수 있습니다!" #존재하지 않는 게시글입니다.
} 
```