### PR TITLE
게시글 수정 관련 로직 구현

### DIFF
--- a/src/main/kotlin/gg/dak/board_api/domain/post/controller/PostController.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/controller/PostController.kt
@@ -1,8 +1,10 @@
 package gg.dak.board_api.domain.post.controller
 
 import gg.dak.board_api.domain.post.data.request.CreatePostRequest
+import gg.dak.board_api.domain.post.data.request.UpdatePostRequest
 import gg.dak.board_api.domain.post.data.response.CreatePostResponse
 import gg.dak.board_api.domain.post.data.response.DeletePostResponse
+import gg.dak.board_api.domain.post.data.response.UpdatePostResponse
 import gg.dak.board_api.domain.post.service.PostService
 import gg.dak.board_api.domain.post.util.PostConverter
 import gg.dak.board_api.global.security.service.LoginAccountService
@@ -36,9 +38,13 @@ class PostController(
             .let { postConverter.toDeleteResponse(it) }
             .let { ResponseEntity.ok(it) }
 
-    @ApiOperation(value = "게시글 수정", notes = "게시글의 제목/내용을 수정합니다. 게시글 작성자만 수정할 수 있습니다.")
+    @ApiOperation(value = "게시글 수정", notes = "게시글의 내용을 수정합니다. 게시글 작성자만 수정할 수 있습니다.")
     @PutMapping("/{idx}")
-    fun changePost(@PathVariable idx: String) {
-
-    }
+    fun updatePost(@PathVariable idx: Long,
+                   @RequestBody request: UpdatePostRequest
+    ): ResponseEntity<UpdatePostResponse> =
+        postConverter.toDto(idx, request)
+            .let { postService.updatePost(it) }
+            .let { postConverter.toUpdateResponse(it) }
+            .let { ResponseEntity.ok(it) }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/data/event/PostUpdateEvent.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/data/event/PostUpdateEvent.kt
@@ -1,0 +1,13 @@
+package gg.dak.board_api.domain.post.data.event
+
+import gg.dak.board_api.domain.post.data.type.BoardType
+import gg.dak.board_api.domain.post.data.type.CategoryType
+
+data class PostUpdateEvent(
+    val idx: Long,
+    val writerIdx: Long,
+    val content: String,
+    val title: String,
+    val board: BoardType,
+    val category: CategoryType,
+)

--- a/src/main/kotlin/gg/dak/board_api/domain/post/data/request/UpdatePostRequest.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/data/request/UpdatePostRequest.kt
@@ -1,0 +1,5 @@
+package gg.dak.board_api.domain.post.data.request
+
+data class UpdatePostRequest(
+    val description: String
+)

--- a/src/main/kotlin/gg/dak/board_api/domain/post/data/request/UpdatePostRequest.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/data/request/UpdatePostRequest.kt
@@ -1,5 +1,5 @@
 package gg.dak.board_api.domain.post.data.request
 
 data class UpdatePostRequest(
-    val description: String
+    val content: String
 )

--- a/src/main/kotlin/gg/dak/board_api/domain/post/data/response/UpdatePostResponse.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/data/response/UpdatePostResponse.kt
@@ -1,0 +1,3 @@
+package gg.dak.board_api.domain.post.data.response
+
+data class UpdatePostResponse(val updatedPostIdx: Long)

--- a/src/main/kotlin/gg/dak/board_api/domain/post/data/type/PostOperationType.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/data/type/PostOperationType.kt
@@ -2,5 +2,6 @@ package gg.dak.board_api.domain.post.data.type
 
 enum class PostOperationType {
     CREATE,
-    DELETE
+    DELETE,
+    UPDATE
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/service/PostService.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/service/PostService.kt
@@ -5,4 +5,5 @@ import gg.dak.board_api.domain.post.data.dto.PostDto
 interface PostService {
     fun createPost(dto: PostDto): PostDto
     fun deletePost(dto: PostDto): PostDto
+    fun updatePost(dto: PostDto): PostDto
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/service/PostServiceImpl.kt
@@ -36,4 +36,8 @@ class PostServiceImpl(
                 postConverter.toDeleteEvent(it.idx)
                 .let { event -> applicationEventPublisher.publishEvent(event) }
             }.let { dto }
+
+    override fun updatePost(dto: PostDto): PostDto {
+        TODO("Not yet implemented")
+    }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/service/PostServiceImpl.kt
@@ -37,7 +37,14 @@ class PostServiceImpl(
                 .let { event -> applicationEventPublisher.publishEvent(event) }
             }.let { dto }
 
-    override fun updatePost(dto: PostDto): PostDto {
-        TODO("Not yet implemented")
-    }
+    override fun updatePost(dto: PostDto): PostDto =
+        postValidator.validate(PostOperationType.UPDATE, dto)
+            .let { postProcessor.process(PostOperationType.UPDATE, dto) }
+            .let { postConverter.toEntity(it) }
+            .let { postRepository.save(it) }
+            .let { postConverter.toDto(it) }
+            .also {
+                postConverter.toUpdateEvent(it)
+                .let { event -> applicationEventPublisher.publishEvent(event) }
+            }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverter.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverter.kt
@@ -5,14 +5,18 @@ import gg.dak.board_api.domain.post.data.entity.Post
 import gg.dak.board_api.domain.post.data.event.PostCreateEvent
 import gg.dak.board_api.domain.post.data.event.PostDeleteEvent
 import gg.dak.board_api.domain.post.data.request.CreatePostRequest
+import gg.dak.board_api.domain.post.data.request.UpdatePostRequest
 import gg.dak.board_api.domain.post.data.response.CreatePostResponse
 import gg.dak.board_api.domain.post.data.response.DeletePostResponse
+import gg.dak.board_api.domain.post.data.response.UpdatePostResponse
 
 interface PostConverter {
     fun toDto(idx: Long): PostDto
+    fun toDto(postIdx: Long, request: UpdatePostRequest): PostDto
     fun toDto(request: CreatePostRequest, writerIdx: Long): PostDto
     fun toCreateResponse(dto: PostDto): CreatePostResponse
     fun toDeleteResponse(dto: PostDto): DeletePostResponse
+    fun toUpdateResponse(dto: PostDto): UpdatePostResponse
     fun toEntity(dto: PostDto): Post
     fun toDto(entity: Post): PostDto
     fun toCreateEvent(dto: PostDto): PostCreateEvent

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverter.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverter.kt
@@ -4,6 +4,7 @@ import gg.dak.board_api.domain.post.data.dto.PostDto
 import gg.dak.board_api.domain.post.data.entity.Post
 import gg.dak.board_api.domain.post.data.event.PostCreateEvent
 import gg.dak.board_api.domain.post.data.event.PostDeleteEvent
+import gg.dak.board_api.domain.post.data.event.PostUpdateEvent
 import gg.dak.board_api.domain.post.data.request.CreatePostRequest
 import gg.dak.board_api.domain.post.data.request.UpdatePostRequest
 import gg.dak.board_api.domain.post.data.response.CreatePostResponse
@@ -21,4 +22,5 @@ interface PostConverter {
     fun toDto(entity: Post): PostDto
     fun toCreateEvent(dto: PostDto): PostCreateEvent
     fun toDeleteEvent(idx: Long): PostDeleteEvent
+    fun toUpdateEvent(dto: PostDto): PostUpdateEvent
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
@@ -5,8 +5,10 @@ import gg.dak.board_api.domain.post.data.entity.Post
 import gg.dak.board_api.domain.post.data.event.PostCreateEvent
 import gg.dak.board_api.domain.post.data.event.PostDeleteEvent
 import gg.dak.board_api.domain.post.data.request.CreatePostRequest
+import gg.dak.board_api.domain.post.data.request.UpdatePostRequest
 import gg.dak.board_api.domain.post.data.response.CreatePostResponse
 import gg.dak.board_api.domain.post.data.response.DeletePostResponse
+import gg.dak.board_api.domain.post.data.response.UpdatePostResponse
 import gg.dak.board_api.domain.post.data.type.BoardType
 import gg.dak.board_api.domain.post.data.type.CategoryType
 import org.springframework.stereotype.Component
@@ -21,6 +23,10 @@ class PostConverterImpl: PostConverter {
         category = CategoryType.UNKNOWN,
         board = BoardType.UNKNOWN
     )
+
+    override fun toDto(postIdx: Long, request: UpdatePostRequest): PostDto {
+        TODO("Not yet implemented")
+    }
 
     override fun toDto(request: CreatePostRequest, writerIdx: Long): PostDto = PostDto(
             idx = -1,
@@ -42,6 +48,9 @@ class PostConverterImpl: PostConverter {
 
     override fun toCreateResponse(dto: PostDto): CreatePostResponse = CreatePostResponse(idx = dto.idx)
     override fun toDeleteResponse(dto: PostDto): DeletePostResponse = DeletePostResponse(deletedPostIdx = dto.idx)
+    override fun toUpdateResponse(dto: PostDto): UpdatePostResponse {
+        TODO("Not yet implemented")
+    }
 
     override fun toEntity(dto: PostDto): Post = Post(
         idx = dto.idx,

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
@@ -4,6 +4,7 @@ import gg.dak.board_api.domain.post.data.dto.PostDto
 import gg.dak.board_api.domain.post.data.entity.Post
 import gg.dak.board_api.domain.post.data.event.PostCreateEvent
 import gg.dak.board_api.domain.post.data.event.PostDeleteEvent
+import gg.dak.board_api.domain.post.data.event.PostUpdateEvent
 import gg.dak.board_api.domain.post.data.request.CreatePostRequest
 import gg.dak.board_api.domain.post.data.request.UpdatePostRequest
 import gg.dak.board_api.domain.post.data.response.CreatePostResponse
@@ -74,4 +75,7 @@ class PostConverterImpl: PostConverter {
     )
 
     override fun toDeleteEvent(idx: Long): PostDeleteEvent = PostDeleteEvent(idx = idx)
+    override fun toUpdateEvent(dto: PostDto): PostUpdateEvent {
+        TODO("Not yet implemented")
+    }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
@@ -75,7 +75,12 @@ class PostConverterImpl: PostConverter {
     )
 
     override fun toDeleteEvent(idx: Long): PostDeleteEvent = PostDeleteEvent(idx = idx)
-    override fun toUpdateEvent(dto: PostDto): PostUpdateEvent {
-        TODO("Not yet implemented")
-    }
+    override fun toUpdateEvent(dto: PostDto): PostUpdateEvent = PostUpdateEvent(
+        idx = dto.idx,
+        writerIdx = dto.writerIdx,
+        content = dto.content,
+        title = dto.title,
+        board = dto.board,
+        category = dto.category,
+    )
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostConverterImpl.kt
@@ -24,9 +24,14 @@ class PostConverterImpl: PostConverter {
         board = BoardType.UNKNOWN
     )
 
-    override fun toDto(postIdx: Long, request: UpdatePostRequest): PostDto {
-        TODO("Not yet implemented")
-    }
+    override fun toDto(postIdx: Long, request: UpdatePostRequest): PostDto = PostDto(
+        idx = postIdx,
+        title = "title",
+        content = request.content,
+        writerIdx = -1,
+        category = CategoryType.UNKNOWN,
+        board = BoardType.UNKNOWN
+    )
 
     override fun toDto(request: CreatePostRequest, writerIdx: Long): PostDto = PostDto(
             idx = -1,
@@ -48,9 +53,7 @@ class PostConverterImpl: PostConverter {
 
     override fun toCreateResponse(dto: PostDto): CreatePostResponse = CreatePostResponse(idx = dto.idx)
     override fun toDeleteResponse(dto: PostDto): DeletePostResponse = DeletePostResponse(deletedPostIdx = dto.idx)
-    override fun toUpdateResponse(dto: PostDto): UpdatePostResponse {
-        TODO("Not yet implemented")
-    }
+    override fun toUpdateResponse(dto: PostDto): UpdatePostResponse = UpdatePostResponse(updatedPostIdx = dto.idx)
 
     override fun toEntity(dto: PostDto): Post = Post(
         idx = dto.idx,

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostProcessorImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostProcessorImpl.kt
@@ -10,5 +10,6 @@ class PostProcessorImpl: PostProcessor {
         when(operation) {
             PostOperationType.CREATE -> dto.copy(idx = 0) //게시글 생성시, 인덱스를 0으로 초기화한다.
             PostOperationType.DELETE -> dto //게시글 삭제시, 어떠한 처리 없이, 그대로 반환한다.
+            PostOperationType.UPDATE -> TODO()
         }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostProcessorImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostProcessorImpl.kt
@@ -2,14 +2,21 @@ package gg.dak.board_api.domain.post.util
 
 import gg.dak.board_api.domain.post.data.dto.PostDto
 import gg.dak.board_api.domain.post.data.type.PostOperationType
+import gg.dak.board_api.domain.post.repository.PostRepository
 import org.springframework.stereotype.Component
 
 @Component
-class PostProcessorImpl: PostProcessor {
+class PostProcessorImpl(
+    private val postRepository: PostRepository,
+    private val postConverter: PostConverter
+): PostProcessor {
     override fun process(operation: PostOperationType, dto: PostDto): PostDto =
         when(operation) {
             PostOperationType.CREATE -> dto.copy(idx = 0) //게시글 생성시, 인덱스를 0으로 초기화한다.
             PostOperationType.DELETE -> dto //게시글 삭제시, 어떠한 처리 없이, 그대로 반환한다.
-            PostOperationType.UPDATE -> TODO()
+            PostOperationType.UPDATE ->
+                postRepository.findById(dto.idx).get()
+                    .let { postConverter.toDto(it) }
+                    .copy(content = dto.content)
         }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostValidatorImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostValidatorImpl.kt
@@ -16,12 +16,12 @@ class PostValidatorImpl(
     private val dailyPostCountRepository: DailyPostCountRepository,
     private val loginAccountService: LoginAccountService
 ): PostValidator {
-    override fun validate(type: PostOperationType, dto: PostDto) {
+    override fun validate(type: PostOperationType, dto: PostDto) =
         when(type) {
             PostOperationType.CREATE -> validateDailyPostLimit(dto)
             PostOperationType.DELETE -> validateIsOwner(dto)
+            PostOperationType.UPDATE -> validateIsOwner(dto)
         }
-    }
 
     private fun validateIsOwner(dto: PostDto) =
         postRepository.findById(dto.idx)

--- a/src/main/kotlin/gg/dak/board_api/domain/post/util/PostValidatorImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/post/util/PostValidatorImpl.kt
@@ -19,15 +19,15 @@ class PostValidatorImpl(
     override fun validate(type: PostOperationType, dto: PostDto) =
         when(type) {
             PostOperationType.CREATE -> validateDailyPostLimit(dto)
-            PostOperationType.DELETE -> validateIsOwner(dto)
-            PostOperationType.UPDATE -> validateIsOwner(dto)
+            PostOperationType.DELETE -> validateIsOwner(dto, "포스트 삭제 정책을 위반하였습니다!", "포스트 작성자만 포스트를 삭제할 수 있습니다!")
+            PostOperationType.UPDATE -> validateIsOwner(dto, "포스트 수정 정책을 위반하였습니다!", "포스트 작성자만 포스트를 수정할 수 있습니다!")
         }
 
-    private fun validateIsOwner(dto: PostDto) =
+    private fun validateIsOwner(dto: PostDto, errorMessage: String, errorDetail: String) =
         postRepository.findById(dto.idx)
-            .let { if(it.isEmpty) throw PolicyValidationException("포스트 삭제 정책을 위반하였습니다!", "존재하지 않는 게시글입니다.") else it.get() }
+            .let { if(it.isEmpty) throw PolicyValidationException(errorMessage, "존재하지 않는 게시글입니다.") else it.get() }
             .let { it.writerIdx == loginAccountService.getLoginAccount().idx}
-            .let { isOwner -> if(!isOwner) throw PolicyValidationException("포스트 삭제 정책을 위반하였습니다!", "포스트 작성자만 포스트를 삭제할 수 있습니다!") }
+            .let { isOwner -> if(!isOwner) throw PolicyValidationException(errorMessage, errorDetail) }
 
     private fun validateDailyPostLimit(dto: PostDto) =
         dailyPostCountRepository.findByAccountIdxAndBoard(dto.writerIdx, dto.board)

--- a/src/test/kotlin/gg/dak/board_api/TestDummyDataUtil.kt
+++ b/src/test/kotlin/gg/dak/board_api/TestDummyDataUtil.kt
@@ -2,6 +2,10 @@ package gg.dak.board_api
 
 import gg.dak.board_api.global.account.data.dto.AccountDto
 import gg.dak.board_api.domain.account.data.enitty.Account
+import gg.dak.board_api.domain.post.data.dto.PostDto
+import gg.dak.board_api.domain.post.data.entity.Post
+import gg.dak.board_api.domain.post.data.type.BoardType
+import gg.dak.board_api.domain.post.data.type.CategoryType
 import kotlin.random.Random
 
 object TestDummyDataUtil {
@@ -22,4 +26,32 @@ object TestDummyDataUtil {
         nickName = nickname((2..5).random()),
         id = id(),
         encodedPassword = encodedPassword())
+
+    fun post() = Post(
+        idx = Random.nextLong(),
+        writerIdx = Random.nextLong(),
+        title = "제목",
+        content = content(),
+        category = CategoryType.values().random(),
+        board = BoardType.values().random()
+    )
+
+    fun content() = listOf("내용", "내용일지도", "내용일거야", "ㅈㄱㄴ").random()
+    fun updatePost(entity: Post, updateContent: String) = Post(
+        idx = entity.idx,
+        writerIdx = entity.writerIdx,
+        title = entity.title,
+        content = updateContent,
+        category = entity.category,
+        board = entity.board,
+    )
+
+    fun toDto(entity: Post) = PostDto(
+        idx = entity.idx,
+        writerIdx = entity.writerIdx,
+        title = entity.title,
+        content = entity.content,
+        category = entity.category,
+        board = entity.board,
+    )
 }

--- a/src/test/kotlin/gg/dak/board_api/domain/post/controller/PostControllerTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/post/controller/PostControllerTest.kt
@@ -2,8 +2,10 @@ package gg.dak.board_api.domain.post.controller
 
 import gg.dak.board_api.domain.post.data.dto.PostDto
 import gg.dak.board_api.domain.post.data.request.CreatePostRequest
+import gg.dak.board_api.domain.post.data.request.UpdatePostRequest
 import gg.dak.board_api.domain.post.data.response.CreatePostResponse
 import gg.dak.board_api.domain.post.data.response.DeletePostResponse
+import gg.dak.board_api.domain.post.data.response.UpdatePostResponse
 import gg.dak.board_api.domain.post.service.PostService
 import gg.dak.board_api.domain.post.util.PostConverter
 import gg.dak.board_api.global.security.service.LoginAccountService
@@ -67,6 +69,27 @@ class PostControllerTest {
 
         //then
         val result = target.deletePost(idx)
+        assertTrue(result.statusCode.is2xxSuccessful)
+        assertNotNull(result.body)
+        assertEquals(result.body, response)
+    }
+
+    @Test @DisplayName("PostController - 포스트 수정 성공테스트")
+    fun testUpdatePost_positive() {
+        //given
+        val idx = Random.nextLong()
+        val request = mock<UpdatePostRequest>()
+        val dto = mock<PostDto>()
+        val updatedDto = mock<PostDto>()
+        val response = mock<UpdatePostResponse>()
+
+        //when
+        whenever(postConverter.toDto(idx, request)).thenReturn(dto)
+        whenever(postService.updatePost(dto)).thenReturn(updatedDto)
+        whenever(postConverter.toUpdateResponse(updatedDto)).thenReturn(response)
+
+        //then
+        val result = target.updatePost(idx, request)
         assertTrue(result.statusCode.is2xxSuccessful)
         assertNotNull(result.body)
         assertEquals(result.body, response)

--- a/src/test/kotlin/gg/dak/board_api/domain/post/service/PostServiceTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/post/service/PostServiceTest.kt
@@ -4,6 +4,7 @@ import gg.dak.board_api.domain.post.data.dto.PostDto
 import gg.dak.board_api.domain.post.data.entity.Post
 import gg.dak.board_api.domain.post.data.event.PostCreateEvent
 import gg.dak.board_api.domain.post.data.event.PostDeleteEvent
+import gg.dak.board_api.domain.post.data.event.PostUpdateEvent
 import gg.dak.board_api.domain.post.data.type.PostOperationType
 import gg.dak.board_api.domain.post.repository.PostRepository
 import gg.dak.board_api.domain.post.util.PostConverter
@@ -79,6 +80,30 @@ class PostServiceTest {
         val result = target.deletePost(dto)
         assertEquals(result, dto)
         verify(postValidator, times(1)).validate(PostOperationType.DELETE, dto)
+        verify(applicationEventPublisher, times(1)).publishEvent(event)
+    }
+
+    @Test @DisplayName("PostService - 포스트 수정 성공테스트")
+    fun testUpdatePost_positive() {
+        //given
+        val dto = mock<PostDto>()
+        val entity = mock<Post>()
+        val savedEntity = mock<Post>()
+        val processedDto = mock<PostDto>()
+        val savedDto = mock<PostDto>()
+        val event = mock<PostUpdateEvent>()
+
+        //when
+        whenever(postProcessor.process(PostOperationType.UPDATE, dto)).thenReturn(processedDto) //전처리과정에서 수정된 포스트 정보를 반환한다.
+        whenever(postConverter.toEntity(processedDto)).thenReturn(entity)
+        whenever(postRepository.save(entity)).thenReturn(savedEntity)
+        whenever(postConverter.toDto(savedEntity)).thenReturn(savedDto)
+        whenever(postConverter.toUpdateEvent(savedDto)).thenReturn(event)
+
+        //then
+        val result = target.updatePost(dto)
+        assertEquals(result, savedDto)
+        verify(postValidator, times(1)).validate(PostOperationType.UPDATE, dto)
         verify(applicationEventPublisher, times(1)).publishEvent(event)
     }
 }

--- a/src/test/kotlin/gg/dak/board_api/domain/post/util/PostValidatorTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/post/util/PostValidatorTest.kt
@@ -99,5 +99,26 @@ class PostValidatorTest {
 
         //then
         assertDoesNotThrow { target.validate(PostOperationType.DELETE, dto) }
+    }/* PolicyValidator - 게시글 수정 로직 검증 성공테스트
+    PolicyValidator.validate(PostOperationType.UPDATE, ?: PostDto)
+    요청자가 작성자가 아니라면, 게시글을 수정할 수 없다.
+     */
+    @Test @DisplayName("PolicyValidator - 게시글 수정 로직 검증 성공테스트")
+    fun testValidateUpdatePost_positive() {
+        //given
+        val dto = mock<PostDto>()
+        val entity = mock<Post>()
+        val ownerIdx = Random.nextLong()
+        val optional = Optional.of(entity)
+        val accountDto = mock<AccountDto>()
+
+        //when
+        whenever(postRepository.findById(dto.idx)).thenReturn(optional)
+        whenever(entity.writerIdx).thenReturn(ownerIdx)
+        whenever(loginAccountService.getLoginAccount()).thenReturn(accountDto)
+        whenever(accountDto.idx).thenReturn(ownerIdx)
+
+        //then
+        assertDoesNotThrow { target.validate(PostOperationType.UPDATE, dto) }
     }
 }


### PR DESCRIPTION
### Summary
게시글에 대한 수정로직을 구현하였습니다!

추가된 endpoint는 [아래](###Endpoints)와 같습니다.
자세한 내용은 #14 를 참고해주세요.

### Endpoint
**PUT** /api/v1/post/32
_RequestBody_
```json
{
  "content": "string"
}
```
_ResponseBody_
```json
{ 
  "updatedPostIdx": 4
}
```
> 정책을 위반하였을 경우, 400 BadRequest를 응답합니다
```json
{
  "status": "POLICY_VIOLATION",
  "message": "포스트 수정 정책을 위반하였습니다!",
  "details": "포스트 작성자만 포스트를 수정할 수 있습니다!" #존재하지 않는 게시글입니다.
}
```
