### PR TITLE
로그인 및 재발급 토큰 관련 오류 수정

### DIFF
--- a/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryController.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryController.kt
@@ -29,7 +29,7 @@ class AccountQueryController(
     ): ResponseEntity<PageableAccountQueryResponse> =
         accountQueryService.findAllAccount(PageRequest.of(page, size))
             .map { accountQueryConverter.toResponse(it) }
-            .let { accountQueryConverter.toPageabelResponse(it.toList()) }
+            .let { accountQueryConverter.toPageableResponse(it.toList()) }
             .let { ResponseEntity.ok(it) }
 
     @ApiOperation(value = "인덱스로 계정 조회", notes = "계정의 인덱스로 계정정보를 조회합니다.")
@@ -39,10 +39,10 @@ class AccountQueryController(
             .let { accountQueryConverter.toResponse(it) }
             .let { ResponseEntity.ok(it) }
 
-    @ApiOperation(value = "아이디로 계정조회", notes = "계정의 아이디로 계정정보를 조회합니다..")
+    @ApiOperation(value = "아이디로 계정조회", notes = "계정의 아이디로 계정정보를 조회합니다.")
     @GetMapping("/id/{id}")
     fun findAccountById(@PathVariable id: String): ResponseEntity<AccountQueryResponse> =
-         accountQueryService.findAccountById(id)
-             .let { accountQueryConverter.toResponse(it) }
-             .let { ResponseEntity.ok(it) }
+        accountQueryService.findAccountById(id)
+            .let { accountQueryConverter.toResponse(it) }
+            .let { ResponseEntity.ok(it) }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/data/event/RefreshTokenDeleteEvent.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/data/event/RefreshTokenDeleteEvent.kt
@@ -1,0 +1,3 @@
+package gg.dak.board_api.domain.account.data.event
+
+class RefreshTokenDeleteEvent(val id: String)

--- a/src/main/kotlin/gg/dak/board_api/domain/account/data/event/UuidTokenDeleteEvent.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/data/event/UuidTokenDeleteEvent.kt
@@ -1,0 +1,6 @@
+package gg.dak.board_api.domain.account.data.event
+
+data class UuidTokenDeleteEvent(
+    val token: String,
+    val payload: Map<String, String>
+)

--- a/src/main/kotlin/gg/dak/board_api/domain/account/listener/RefreshTokenCacheListener.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/listener/RefreshTokenCacheListener.kt
@@ -3,6 +3,7 @@ package gg.dak.board_api.domain.account.listener
 import gg.dak.board_api.domain.account.config.LoginProperties
 import gg.dak.board_api.domain.account.data.enitty.RefreshToken
 import gg.dak.board_api.domain.account.data.event.LoginTokenCreateEvent
+import gg.dak.board_api.domain.account.data.event.RefreshTokenDeleteEvent
 import gg.dak.board_api.domain.account.repository.RefreshTokenRepository
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
@@ -17,5 +18,10 @@ class RefreshTokenCacheListener(
         loginProperties.refreshTokenProperties.expireSecond
             .let { RefreshToken(event.id, event.refreshToken, it) }
             .let { refreshTokenRepository.save(it) }
+    }
+
+    @EventListener(RefreshTokenDeleteEvent::class)
+    fun handle(event: RefreshTokenDeleteEvent) {
+        refreshTokenRepository.deleteById(event.id)
     }
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/listener/UuidTokenDeleteEventListener.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/listener/UuidTokenDeleteEventListener.kt
@@ -1,0 +1,20 @@
+package gg.dak.board_api.domain.account.listener
+
+import gg.dak.board_api.domain.account.data.event.RefreshTokenDeleteEvent
+import gg.dak.board_api.domain.account.data.event.UuidTokenDeleteEvent
+import gg.dak.board_api.domain.account.data.type.TokenType
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class UuidTokenDeleteEventListener(
+    private val applicationEventPublisher: ApplicationEventPublisher
+) {
+    @EventListener(UuidTokenDeleteEvent::class)
+    fun handle(event: UuidTokenDeleteEvent) {
+        if(event.payload["type"].equals(TokenType.LOGIN_REFRESH.key))
+            RefreshTokenDeleteEvent(event.payload["id"]!!) //나중에 validation 가능할지 생각해보기
+                .let { applicationEventPublisher.publishEvent(it) }
+    }
+}

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountQueryConverter.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/AccountQueryConverter.kt
@@ -6,6 +6,6 @@ import gg.dak.board_api.domain.account.data.response.PageableAccountQueryRespons
 
 interface AccountQueryConverter {
     fun toResponse(dto: AccountDto): AccountQueryResponse
-    fun toPageabelResponse(list: List<AccountQueryResponse>): PageableAccountQueryResponse
+    fun toPageableResponse(list: List<AccountQueryResponse>): PageableAccountQueryResponse
 
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/impl/AccountQueryConverterImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/impl/AccountQueryConverterImpl.kt
@@ -10,5 +10,5 @@ import org.springframework.stereotype.Component
 @Component
 class AccountQueryConverterImpl: AccountQueryConverter {
     override fun toResponse(dto: AccountDto): AccountQueryResponse = AccountQueryResponse(idx = dto.idx, nickname = dto.nickname, id = dto.id)
-    override fun toPageabelResponse(list: List<AccountQueryResponse>): PageableAccountQueryResponse = PageableAccountQueryResponse(PageImpl(list))
+    override fun toPageableResponse(list: List<AccountQueryResponse>): PageableAccountQueryResponse = PageableAccountQueryResponse(PageImpl(list))
 }

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/impl/LoginTokenGeneratorImpl.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/impl/LoginTokenGeneratorImpl.kt
@@ -4,6 +4,8 @@ import gg.dak.board_api.domain.account.config.LoginProperties
 import gg.dak.board_api.domain.account.data.dto.LoginTokenDto
 import gg.dak.board_api.domain.account.data.event.LoginTokenCreateEvent
 import gg.dak.board_api.domain.account.data.type.TokenType
+import gg.dak.board_api.domain.account.repository.RefreshTokenRepository
+import gg.dak.board_api.domain.account.repository.UuidTokenRepository
 import gg.dak.board_api.domain.account.util.JwtTokenGenerator
 import gg.dak.board_api.domain.account.util.LoginTokenGenerator
 import gg.dak.board_api.global.account.util.UuidTokenGenerator
@@ -16,14 +18,18 @@ class LoginTokenGeneratorImpl(
     private val loginProperties: LoginProperties,
     private val jwtTokenGenerator: JwtTokenGenerator,
     @Qualifier("volatility") private val uuidTokenGenerator: UuidTokenGenerator,
-    private val applicationEventPublisher: ApplicationEventPublisher
+    private val applicationEventPublisher: ApplicationEventPublisher,
+    private val uuidTokenRepository: UuidTokenRepository,
+    private val refreshTokenRepository: RefreshTokenRepository
 ) : LoginTokenGenerator {
     override fun generate(id: String): LoginTokenDto =
-        jwtTokenGenerator.generate( //accessToken을 발급합니다.
+        refreshTokenRepository.findById(id) //기존에 재발급토큰이 존재하였는지 검사합니다.
+            .let { if(it.isPresent) uuidTokenRepository.deleteById(it.get().token) } //기존에 재발금토큰이 존재하였다면, 이를 제거합니다.
+            .let { jwtTokenGenerator.generate( //accessToken을 발급합니다.
                 mapOf(
                     "id" to id,
                     "type" to TokenType.LOGIN_ACCESS.key
-                ), loginProperties.accessTokenProperties.expireSecond)
+                ), loginProperties.accessTokenProperties.expireSecond) }
             .let { it to uuidTokenGenerator.generate( //refreshToken을 발급합니다.
                 mapOf(
                     "id" to id,

--- a/src/main/kotlin/gg/dak/board_api/domain/account/util/impl/VolatilityRedisUuidTokenGenerator.kt
+++ b/src/main/kotlin/gg/dak/board_api/domain/account/util/impl/VolatilityRedisUuidTokenGenerator.kt
@@ -1,9 +1,11 @@
 package gg.dak.board_api.domain.account.util.impl
 
 import gg.dak.board_api.domain.account.data.enitty.UuidToken
+import gg.dak.board_api.domain.account.data.event.UuidTokenDeleteEvent
 import gg.dak.board_api.domain.account.exception.UnknownUuidTokenException
 import gg.dak.board_api.domain.account.repository.UuidTokenRepository
 import gg.dak.board_api.global.account.util.UuidTokenGenerator
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.util.*
 
@@ -11,7 +13,8 @@ import java.util.*
 //decode 시 decode된 token을 삭제합니다.
 @Component("volatility")
 class VolatilityRedisUuidTokenGenerator(
-    private val uuidTokenRepository: UuidTokenRepository
+    private val uuidTokenRepository: UuidTokenRepository,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ): UuidTokenGenerator {
     override fun generate(payload: Map<String, String>, expireSecond: Long): String =
         UUID.randomUUID().toString()
@@ -25,4 +28,5 @@ class VolatilityRedisUuidTokenGenerator(
                 if(it.isEmpty) throw UnknownUuidTokenException("존재하지 않는 UUID토큰입니다!", token)
                 else uuidTokenRepository.deleteById(token)
             }.get().data
+            .also { UuidTokenDeleteEvent(token, it).let { event -> applicationEventPublisher.publishEvent(event) } }
 }

--- a/src/test/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryControllerTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/controller/AccountQueryControllerTest.kt
@@ -49,7 +49,7 @@ class AccountQueryControllerTest {
         //when
         whenever(accountQueryService.findAllAccount(pagination)).thenReturn(data)
         whenever(accountQueryConverter.toResponse(any())).thenReturn(response)
-        whenever(accountQueryConverter.toPageabelResponse(any())).thenReturn(pageableResponse)
+        whenever(accountQueryConverter.toPageableResponse(any())).thenReturn(pageableResponse)
 
         //then
         val result = target.findAllAccountWithPagination(page = page, size = size)

--- a/src/test/kotlin/gg/dak/board_api/domain/account/util/LoginTokenGeneratorTest.kt
+++ b/src/test/kotlin/gg/dak/board_api/domain/account/util/LoginTokenGeneratorTest.kt
@@ -2,19 +2,20 @@ package gg.dak.board_api.domain.account.util
 
 import gg.dak.board_api.TestDummyDataUtil
 import gg.dak.board_api.domain.account.config.LoginProperties
+import gg.dak.board_api.domain.account.data.enitty.RefreshToken
 import gg.dak.board_api.domain.account.data.event.LoginTokenCreateEvent
 import gg.dak.board_api.domain.account.data.type.TokenType
+import gg.dak.board_api.domain.account.repository.RefreshTokenRepository
+import gg.dak.board_api.domain.account.repository.UuidTokenRepository
 import gg.dak.board_api.domain.account.util.impl.LoginTokenGeneratorImpl
 import gg.dak.board_api.global.account.util.UuidTokenGenerator
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import org.mockito.kotlin.*
 import org.springframework.context.ApplicationEventPublisher
+import java.util.*
 import kotlin.random.Random
 
 class LoginTokenGeneratorTest {
@@ -23,6 +24,8 @@ class LoginTokenGeneratorTest {
     private lateinit var uuidTokenGenerator: UuidTokenGenerator
     private lateinit var applicationEventPublisher: ApplicationEventPublisher
     private lateinit var target: LoginTokenGenerator
+    private lateinit var uuidTokenRepository: UuidTokenRepository
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
 
     @BeforeEach
     fun setUp() {
@@ -30,7 +33,9 @@ class LoginTokenGeneratorTest {
         jwtTokenGenerator = mock()
         uuidTokenGenerator = mock()
         applicationEventPublisher = mock()
-        target = LoginTokenGeneratorImpl(loginProperties, jwtTokenGenerator, uuidTokenGenerator, applicationEventPublisher)
+        uuidTokenRepository = mock()
+        refreshTokenRepository = mock()
+        target = LoginTokenGeneratorImpl(loginProperties, jwtTokenGenerator, uuidTokenGenerator, applicationEventPublisher, uuidTokenRepository, refreshTokenRepository)
     }
 
     /* LoginTokenGenerator - 로그인 토큰 발급 성공테스트
@@ -40,20 +45,22 @@ class LoginTokenGeneratorTest {
     - jwtTokenGenerator를 통해 accessToken을 발급한다.
     - uuidTokenGenerator를 통해 refreshToken을 발급한다.
      */
-    @Test @DisplayName("LoginTokenGenerator - 로그인 토큰 생성 성공테스트")
-    fun testGenerateLoginToken_positive() {
+    @Test @DisplayName("LoginTokenGenerator - 로그인 토큰 생성 성공테스트A")
+    fun testGenerateLoginToken_positiveA() { //기존에 재발급토큰이 존재하지 않았을 경우
         //given
         val id = TestDummyDataUtil.id()
         val refreshTokenExpireSecond = Random.nextLong()
         val accessTokenExpireSecond = Random.nextLong()
         val accessToken = TestDummyDataUtil.token()
         val refreshToken = TestDummyDataUtil.token()
+        val optional = Optional.empty<RefreshToken>()
 
         //when
         whenever(loginProperties.refreshTokenProperties).thenReturn(mock())
         whenever(loginProperties.accessTokenProperties).thenReturn(mock())
         whenever(loginProperties.accessTokenProperties.expireSecond).thenReturn(accessTokenExpireSecond)
         whenever(loginProperties.refreshTokenProperties.expireSecond).thenReturn(refreshTokenExpireSecond)
+        whenever(refreshTokenRepository.findById(id)).thenReturn(optional)
         whenever(jwtTokenGenerator.generate(mapOf("id" to id,"type" to TokenType.LOGIN_ACCESS.key), accessTokenExpireSecond)).thenReturn(accessToken)
         whenever(uuidTokenGenerator.generate(mapOf(
             "id" to id,
@@ -67,5 +74,40 @@ class LoginTokenGeneratorTest {
         assertEquals(result.accessToken, accessToken)
         assertEquals(result.refreshToken, refreshToken)
         verify(applicationEventPublisher, times(1)).publishEvent(LoginTokenCreateEvent(id, accessToken, refreshToken))
+        verify(uuidTokenRepository, times(0)).deleteById(any())
+    }
+
+    @Test @DisplayName("LoginTokenGenerator - 로그인 토큰 생성 성공테스트B")
+    fun testGenerateLoginToken_positiveB() { //기존에 재발급토큰이 존재하였을 경우
+        //given
+        val id = TestDummyDataUtil.id()
+        val refreshTokenExpireSecond = Random.nextLong()
+        val accessTokenExpireSecond = Random.nextLong()
+        val accessToken = TestDummyDataUtil.token()
+        val legacyRefreshToken = TestDummyDataUtil.token()
+        val refreshToken = TestDummyDataUtil.token()
+        val refreshTokenEntity = RefreshToken(id, legacyRefreshToken, -1)
+        val optional = Optional.of(refreshTokenEntity)
+
+        //when
+        whenever(loginProperties.refreshTokenProperties).thenReturn(mock())
+        whenever(loginProperties.accessTokenProperties).thenReturn(mock())
+        whenever(loginProperties.accessTokenProperties.expireSecond).thenReturn(accessTokenExpireSecond)
+        whenever(loginProperties.refreshTokenProperties.expireSecond).thenReturn(refreshTokenExpireSecond)
+        whenever(refreshTokenRepository.findById(id)).thenReturn(optional)
+        whenever(jwtTokenGenerator.generate(mapOf("id" to id,"type" to TokenType.LOGIN_ACCESS.key), accessTokenExpireSecond)).thenReturn(accessToken)
+        whenever(uuidTokenGenerator.generate(mapOf(
+            "id" to id,
+            "type" to TokenType.LOGIN_REFRESH.key,
+            "expiration" to false.toString()
+        ), refreshTokenExpireSecond)).thenReturn(refreshToken)
+
+        //then
+        val result = target.generate(id)
+
+        assertEquals(result.accessToken, accessToken)
+        assertEquals(result.refreshToken, refreshToken)
+        verify(applicationEventPublisher, times(1)).publishEvent(LoginTokenCreateEvent(id, accessToken, refreshToken))
+        verify(uuidTokenRepository, times(1)).deleteById(legacyRefreshToken)
     }
 }


### PR DESCRIPTION
### Summary
로그인시 재발급토큰이 여러개가되는 오류를 해결하였습니다!
그 외에도 캐시데이터와 원본데이터간의 일관성을 맞추기위한 작업을 수행하였습니다.